### PR TITLE
Expand connection (and connection property) model

### DIFF
--- a/davinci/models_connection.go
+++ b/davinci/models_connection.go
@@ -1,0 +1,91 @@
+package davinci
+
+import "encoding/json"
+
+type _Connection Connection
+type Connection struct {
+	AdditionalProperties map[string]interface{}        `json:"additionalProperties,omitempty"`
+	CustomerID           *string                       `json:"customerId,omitempty"`
+	ConnectorID          *string                       `json:"connectorId,omitempty"`
+	Name                 *string                       `json:"name,omitempty"`
+	CreatedDate          *EpochTime                    `json:"createdDate,omitempty"`
+	Properties           map[string]ConnectionProperty `json:"properties,omitempty"`
+	UpdatedDate          *EpochTime                    `json:"updatedDate,omitempty"`
+	ConnectionID         *string                       `json:"connectionId,omitempty"`
+	CompanyID            *string                       `json:"companyId,omitempty"`
+}
+
+func (o Connection) MarshalJSON() ([]byte, error) {
+	result, err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(result)
+}
+
+func (o Connection) ToMap() (map[string]interface{}, error) {
+
+	result := map[string]interface{}{}
+
+	if o.CustomerID != nil {
+		result["customerId"] = o.CustomerID
+	}
+
+	if o.ConnectorID != nil {
+		result["connectorId"] = o.ConnectorID
+	}
+
+	if o.Name != nil {
+		result["name"] = o.Name
+	}
+
+	if o.CreatedDate != nil {
+		result["createdDate"] = o.CreatedDate
+	}
+
+	if o.Properties != nil {
+		result["properties"] = o.Properties
+	}
+
+	if o.UpdatedDate != nil {
+		result["updatedDate"] = o.UpdatedDate
+	}
+
+	if o.ConnectionID != nil {
+		result["connectionId"] = o.ConnectionID
+	}
+
+	if o.CompanyID != nil {
+		result["companyId"] = o.CompanyID
+	}
+
+	for k, v := range o.AdditionalProperties {
+		result[k] = v
+	}
+
+	return result, nil
+}
+
+func (o *Connection) UnmarshalJSON(bytes []byte) (err error) {
+	varConnection := _Connection{}
+
+	if err = json.Unmarshal(bytes, &varConnection); err == nil {
+		*o = Connection(varConnection)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customerId")
+		delete(additionalProperties, "connectorId")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "createdDate")
+		delete(additionalProperties, "properties")
+		delete(additionalProperties, "updatedDate")
+		delete(additionalProperties, "connectionId")
+		delete(additionalProperties, "companyId")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+}

--- a/davinci/models_connection_property.go
+++ b/davinci/models_connection_property.go
@@ -1,0 +1,127 @@
+package davinci
+
+import "encoding/json"
+
+type _ConnectionProperty ConnectionProperty
+type ConnectionProperty struct {
+	AdditionalProperties map[string]interface{}        `json:"additionalProperties,omitempty"`
+	CompanyId            *string                       `json:"companyId,omitempty"`
+	ConstructItems       []string                      `json:"constructItems,omitempty"`
+	CreatedDate          *EpochTime                    `json:"createdDate,omitempty"`
+	CustomerId           *string                       `json:"customerId,omitempty"`
+	DisplayName          *string                       `json:"displayName,omitempty"`
+	Info                 *string                       `json:"info,omitempty"`
+	Placeholder          *string                       `json:"placeholder,omitempty"`
+	PreferredControlType *string                       `json:"preferredControlType,omitempty"`
+	Properties           map[string]ConnectionProperty `json:"properties,omitempty"`
+	Required             *bool                         `json:"required,omitempty"`
+	Sections             []string                      `json:"sections,omitempty"`
+	Secure               *bool                         `json:"secure,omitempty"`
+	Type                 *string                       `json:"type,omitempty"`
+	Value                interface{}                   `json:"value,omitempty"`
+}
+
+func (o ConnectionProperty) MarshalJSON() ([]byte, error) {
+	result, err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(result)
+}
+
+func (o ConnectionProperty) ToMap() (map[string]interface{}, error) {
+
+	result := map[string]interface{}{}
+
+	if o.CompanyId != nil {
+		result["companyId"] = o.CompanyId
+	}
+
+	if o.ConstructItems != nil {
+		result["constructItems"] = o.ConstructItems
+	}
+
+	if o.CreatedDate != nil {
+		result["createdDate"] = o.CreatedDate
+	}
+
+	if o.CustomerId != nil {
+		result["customerId"] = o.CustomerId
+	}
+
+	if o.DisplayName != nil {
+		result["displayName"] = o.DisplayName
+	}
+
+	if o.Info != nil {
+		result["info"] = o.Info
+	}
+
+	if o.Placeholder != nil {
+		result["placeholder"] = o.Placeholder
+	}
+
+	if o.PreferredControlType != nil {
+		result["preferredControlType"] = o.PreferredControlType
+	}
+
+	if o.Properties != nil {
+		result["properties"] = o.Properties
+	}
+
+	if o.Required != nil {
+		result["required"] = o.Required
+	}
+
+	if o.Sections != nil {
+		result["sections"] = o.Sections
+	}
+
+	if o.Secure != nil {
+		result["secure"] = o.Secure
+	}
+
+	if o.Type != nil {
+		result["type"] = o.Type
+	}
+
+	if o.Value != nil {
+		result["value"] = o.Value
+	}
+
+	for k, v := range o.AdditionalProperties {
+		result[k] = v
+	}
+
+	return result, nil
+}
+
+func (o *ConnectionProperty) UnmarshalJSON(bytes []byte) (err error) {
+	varConnectionProperty := _ConnectionProperty{}
+
+	if err = json.Unmarshal(bytes, &varConnectionProperty); err == nil {
+		*o = ConnectionProperty(varConnectionProperty)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "companyId")
+		delete(additionalProperties, "constructItems")
+		delete(additionalProperties, "createdDate")
+		delete(additionalProperties, "customerId")
+		delete(additionalProperties, "displayName")
+		delete(additionalProperties, "info")
+		delete(additionalProperties, "placeholder")
+		delete(additionalProperties, "preferredControlType")
+		delete(additionalProperties, "properties")
+		delete(additionalProperties, "required")
+		delete(additionalProperties, "sections")
+		delete(additionalProperties, "secure")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+}

--- a/davinci/models_connectors.go
+++ b/davinci/models_connectors.go
@@ -1,19 +1,5 @@
 package davinci
 
-// Representation of an instantiated connector
-// All fields are set with omitempty as nil values aren't allowed
-// to various requests requiring specific fields.
-type Connection struct {
-	CustomerID   *string                `json:"customerId,omitempty"`
-	ConnectorID  *string                `json:"connectorId,omitempty"`
-	Name         *string                `json:"name,omitempty"`
-	CreatedDate  *EpochTime             `json:"createdDate,omitempty"`
-	Properties   map[string]interface{} `json:"properties,omitempty"`
-	UpdatedDate  *EpochTime             `json:"updatedDate,omitempty"`
-	ConnectionID *string                `json:"connectionId,omitempty"`
-	CompanyID    *string                `json:"companyId,omitempty"`
-}
-
 // CustomAuth is a field of the Properties struct
 // but is kept separate because the structure is known.
 // This is used to unmarshal the properties["customAuth"] field of a connection response.


### PR DESCRIPTION
Expand the connection data model to support the `customAuth`, `openid`, `oauth2`, `customAttributes` and `saml` properties in the Terraform provider