### PR TITLE
Redefine flow attributes for stable import

### DIFF
--- a/davinci/connections_test.go
+++ b/davinci/connections_test.go
@@ -147,12 +147,12 @@ var testDataConnections = map[string]interface{}{
 				s := "pingOneMfaConnector"
 				return &s
 			}(),
-			Properties: map[string]interface{}{
-				"envId": map[string]interface{}{
-					"value": "1234",
+			Properties: map[string]davinci.ConnectionProperty{
+				"envId": {
+					Value: "1234",
 				},
-				"policyId": map[string]interface{}{
-					"value": "1234",
+				"policyId": {
+					Value: "1234",
 				},
 			},
 		},
@@ -165,9 +165,9 @@ var testDataConnections = map[string]interface{}{
 				s := "pingOneSSOConnector"
 				return &s
 			}(),
-			Properties: map[string]interface{}{
-				"envId": map[string]interface{}{
-					"value": "1234",
+			Properties: map[string]davinci.ConnectionProperty{
+				"envId": {
+					Value: "1234",
 				},
 			},
 		},
@@ -180,7 +180,7 @@ var testDataConnections = map[string]interface{}{
 				s := "pingOneMfaConnector"
 				return &s
 			}(),
-			Properties: map[string]interface{}{},
+			Properties: map[string]davinci.ConnectionProperty{},
 		},
 		"dUpdateNeg": {
 			Name: func() *string {
@@ -191,9 +191,9 @@ var testDataConnections = map[string]interface{}{
 				s := "pingOneMfaConnector"
 				return &s
 			}(),
-			Properties: map[string]interface{}{
-				"InvalidProperty": map[string]interface{}{
-					"value": "Foo",
+			Properties: map[string]davinci.ConnectionProperty{
+				"InvalidProperty": {
+					Value: "Foo",
 				},
 			},
 		},
@@ -243,11 +243,11 @@ var testDataConnections = map[string]interface{}{
 				s := "genericConnector"
 				return &s
 			}(),
-			Properties: map[string]interface{}{
-				"customAuth": map[string]interface{}{
-					"properties": map[string]interface{}{
-						"providerName": map[string]interface{}{
-							"value": "foooidc",
+			Properties: map[string]davinci.ConnectionProperty{
+				"customAuth": {
+					Properties: map[string]davinci.ConnectionProperty{
+						"providerName": {
+							Value: "foooidc",
 						},
 					},
 				},
@@ -345,9 +345,9 @@ func TestConnection_Read(t *testing.T) {
 				}
 			}
 			fmt.Printf("res is: %v\n", res)
-			if res.Properties["customAuth"] != nil {
+			if v, ok := res.Properties["customAuth"]; ok {
 				fmt.Println("customAuth is not nil, will attempt to unmarshal")
-				a, _ := json.Marshal(res.Properties["customAuth"])
+				a, _ := json.Marshal(v)
 				var customAuth davinci.CustomAuth
 				err := json.Unmarshal(a, &customAuth)
 				if err != nil {
@@ -434,9 +434,9 @@ func TestConnection_CreateInitialized(t *testing.T) {
 			thisArg.ConnectionID = resp.ConnectionID
 			args[i] = thisArg
 			fmt.Printf("resp is: %#v\n", resp)
-			if resp.Properties["customAuth"] != nil {
+			if v, ok := resp.Properties["customAuth"]; ok {
 				fmt.Println("customAuth is not nil, will attempt to unmarshal")
-				a, _ := json.Marshal(resp.Properties["customAuth"])
+				a, _ := json.Marshal(v)
 				var customAuth davinci.CustomAuth
 				err := json.Unmarshal(a, &customAuth)
 				if err != nil {

--- a/davinci/models_flow.go
+++ b/davinci/models_flow.go
@@ -13,11 +13,7 @@ type Flow struct {
 
 type FlowConfiguration struct {
 	FlowUpdateConfiguration
-	FlowColor            *string       `json:"flowColor,omitempty" davinci:"flowColor,designercue,omitempty"`
-	InputSchemaCompiled  interface{}   `json:"inputSchemaCompiled,omitempty" davinci:"inputSchemaCompiled,config,omitempty"`
-	IsInputSchemaSaved   *bool         `json:"isInputSchemaSaved,omitempty" davinci:"isInputSchemaSaved,config,omitempty"`
-	IsOutputSchemaSaved  bool          `json:"isOutputSchemaSaved" davinci:"isOutputSchemaSaved,config"`
-	OutputSchemaCompiled *OutputSchema `json:"outputSchemaCompiled,omitempty" davinci:"outputSchemaCompiled,*,omitempty"` //compiled is used in exported flow json, must be converted to JUST output when updating flow.
+	FlowColor *string `json:"flowColor,omitempty" davinci:"flowColor,designercue,omitempty"`
 }
 
 type FlowUpdateConfiguration struct {
@@ -42,8 +38,12 @@ type FlowMetadata struct {
 	Description          *string        `json:"description,omitempty" davinci:"description,flowmetadata,omitempty"`
 	EnabledGraphData     interface{}    `json:"enabledGraphData,omitempty" davinci:"enabledGraphData,flowmetadata,omitempty"`
 	FunctionConnectionID interface{}    `json:"functionConnectionId,omitempty" davinci:"functionConnectionId,flowmetadata,omitempty"`
+	InputSchemaCompiled  interface{}    `json:"inputSchemaCompiled,omitempty" davinci:"inputSchemaCompiled,flowmetadata,omitempty"`
+	IsInputSchemaSaved   *bool          `json:"isInputSchemaSaved,omitempty" davinci:"isInputSchemaSaved,flowmetadata,omitempty"`
+	IsOutputSchemaSaved  bool           `json:"isOutputSchemaSaved" davinci:"isOutputSchemaSaved,flowmetadata"`
 	Name                 string         `json:"name" davinci:"name,flowmetadata"`
 	Orx                  *string        `json:"orx,omitempty" davinci:"orx,flowmetadata,omitempty"`
+	OutputSchemaCompiled *OutputSchema  `json:"outputSchemaCompiled,omitempty" davinci:"outputSchemaCompiled,*,omitempty"` //compiled is used in exported flow json, must be converted to JUST output when updating flow.
 	Timeouts             interface{}    `json:"timeouts,omitempty" davinci:"timeouts,flowmetadata,omitempty"`
 	Variables            []FlowVariable `json:"variables,omitempty" davinci:"variables,*,omitempty"`
 }

--- a/davinci/test/test_data.go
+++ b/davinci/test/test_data.go
@@ -1544,10 +1544,6 @@ func Data_FullBasic() davinci.Flow {
 				v := "#E3F0FF"
 				return &v
 			}(),
-			InputSchemaCompiled:  nil,
-			IsInputSchemaSaved:   nil,
-			IsOutputSchemaSaved:  false,
-			OutputSchemaCompiled: nil,
 		},
 		FlowEnvironmentMetadata: davinci.FlowEnvironmentMetadata{
 			CompanyID:   "2c6123ae-108f-4d11-bcc2-6c8f4dfa9fdb",
@@ -1574,6 +1570,10 @@ func Data_FullBasic() davinci.Flow {
 			Name:                 "full-basic",
 			Orx:                  nil,
 			Timeouts:             "null",
+			InputSchemaCompiled:  nil,
+			IsInputSchemaSaved:   nil,
+			IsOutputSchemaSaved:  false,
+			OutputSchemaCompiled: nil,
 			Variables: []davinci.FlowVariable{
 				{
 					AdditionalProperties: map[string]interface{}{


### PR DESCRIPTION
Redefined the following from "configuration" to "metadata":
`Flow.InputSchemaCompiled`
`Flow.IsInputSchemaSaved`
`Flow.IsOutputSchemaSaved`
`Flow.OutputSchemaCompiled`

### Testing

```
go test -timeout 300s -run ^ github.com/samir-gandhi/davinci-client-go/davinci
```

```
ok      github.com/samir-gandhi/davinci-client-go/davinci       101.304s
```