### PR TITLE
support includeVariableValues query param

### DIFF
--- a/davinci/codec_struct.go
+++ b/davinci/codec_struct.go
@@ -74,7 +74,7 @@ func (d StructCodec) DecodeValue(data []byte, v reflect.Value) error {
 
 		mappedFields = append(mappedFields, jsonFieldName)
 
-		if !slices.Contains([]string{"*", "-", "designercue", "environmentmetadata", "config", "flowmetadata", "versionmetadata", "unmappedproperties"}, fieldPurpose) {
+		if !slices.Contains([]string{"*", "-", "designercue", "environmentmetadata", "config", "flowmetadata", "flowvariables", "versionmetadata", "unmappedproperties"}, fieldPurpose) {
 			return fmt.Errorf("davinci export field purpose %s is not recognised", fieldPurpose)
 		}
 
@@ -98,6 +98,7 @@ func (d StructCodec) DecodeValue(data []byte, v reflect.Value) error {
 			(fieldPurpose == "environmentmetadata" && !d.dCtx.Opts.IgnoreEnvironmentMetadata) ||
 			(fieldPurpose == "config" && !d.dCtx.Opts.IgnoreConfig) ||
 			(fieldPurpose == "flowmetadata" && !d.dCtx.Opts.IgnoreFlowMetadata) ||
+			(fieldPurpose == "flowvariables" && !d.dCtx.Opts.IgnoreFlowVariables) ||
 			(fieldPurpose == "versionmetadata" && !d.dCtx.Opts.IgnoreVersionMetadata) ||
 			fieldPurpose == "*" {
 
@@ -206,7 +207,7 @@ func (d StructCodec) encodePartValue(v reflect.Value, unmappedPropertiesField *r
 		jsonFieldName := tagParts[0]
 		fieldPurpose := tagParts[1]
 
-		if !slices.Contains([]string{"*", "-", "designercue", "environmentmetadata", "config", "flowmetadata", "versionmetadata", "unmappedproperties"}, fieldPurpose) {
+		if !slices.Contains([]string{"*", "-", "designercue", "environmentmetadata", "config", "flowmetadata", "flowvariables", "versionmetadata", "unmappedproperties"}, fieldPurpose) {
 			return nil, fmt.Errorf("davinci export field purpose %s is not recognised", fieldPurpose)
 		}
 
@@ -230,6 +231,7 @@ func (d StructCodec) encodePartValue(v reflect.Value, unmappedPropertiesField *r
 			(fieldPurpose == "environmentmetadata" && !d.eCtx.Opts.IgnoreEnvironmentMetadata) ||
 			(fieldPurpose == "config" && !d.eCtx.Opts.IgnoreConfig) ||
 			(fieldPurpose == "flowmetadata" && !d.eCtx.Opts.IgnoreFlowMetadata) ||
+			(fieldPurpose == "flowvariables" && !d.eCtx.Opts.IgnoreFlowVariables) ||
 			(fieldPurpose == "versionmetadata" && !d.eCtx.Opts.IgnoreVersionMetadata) ||
 			fieldPurpose == "*" {
 

--- a/davinci/flow_equality.go
+++ b/davinci/flow_equality.go
@@ -14,6 +14,7 @@ type ExportCmpOpts struct {
 	IgnoreUnmappedProperties  bool
 	IgnoreVersionMetadata     bool
 	IgnoreFlowMetadata        bool
+	IgnoreFlowVariables       bool
 }
 
 func Equal(x, y interface{}, cmpOpts ExportCmpOpts, opts ...cmp.Option) bool {

--- a/davinci/flow_valid.go
+++ b/davinci/flow_valid.go
@@ -7,37 +7,57 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func ValidFlowsInfoExport(data []byte, cmpOpts ExportCmpOpts) bool {
+type EnumValidFlowObjError string
+
+const (
+	ENUM_VALID_FLOW_OBJ_ERROR_NONE                           EnumValidFlowObjError = "NONE"
+	ENUM_VALID_FLOW_OBJ_ERROR_INVALID_JSON                   EnumValidFlowObjError = "INVALID_JSON"
+	ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_UNMARSHAL            EnumValidFlowObjError = "CANNOT_DV_UNMARSHAL"
+	ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_MARSHAL              EnumValidFlowObjError = "CANNOT_DV_MARSHAL"
+	ENUM_VALID_FLOW_OBJ_ERROR_EMPTY_FLOW                     EnumValidFlowObjError = "EMPTY_FLOW"
+	ENUM_VALID_FLOW_OBJ_ERROR_OBJECT_EQUATES_EMPTY           EnumValidFlowObjError = "OBJECT_EQUATES_EMPTY"
+	ENUM_VALID_FLOW_OBJ_ERROR_NO_FLOW_DEF                    EnumValidFlowObjError = "NO_FLOW_DEF"
+	ENUM_VALID_FLOW_OBJ_ERROR_MULTIPLE_FLOW_DEF              EnumValidFlowObjError = "MULTIPLE_FLOW_DEF"
+	ENUM_VALID_FLOW_OBJ_ERROR_INVALID_REQUIRED_FLOW_DEF      EnumValidFlowObjError = "INVALID_REQUIRED_FLOW_DEF"
+	ENUM_VALID_FLOW_OBJ_ERROR_UNKNOWN_ADDITIONAL_JSON_VALUES EnumValidFlowObjError = "UNKNOWN_ADDITIONAL_JSON_VALUES"
+)
+
+func ValidFlowsInfoExport(data []byte, cmpOpts ExportCmpOpts) (ok bool, errorCode EnumValidFlowObjError, diff *string, err error) {
 	if ok := json.Valid(data); !ok {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_JSON, nil, nil
 	}
 
 	var flowTypeObject FlowsInfo
 
 	if err := Unmarshal([]byte(data), &flowTypeObject, cmpOpts); err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_UNMARSHAL, nil, err
 	}
 
 	jsonBytes, err := Marshal(flowTypeObject, cmpOpts)
 	if err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_MARSHAL, nil, err
 	}
 
 	if string(jsonBytes) == "{}" {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_EMPTY_FLOW, nil, nil
 	}
 
 	if cmp.Equal(flowTypeObject, FlowsInfo{}, cmpopts.EquateEmpty()) {
-		return false
+		diff := cmp.Diff(flowTypeObject, FlowsInfo{}, cmpopts.EquateEmpty())
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_OBJECT_EQUATES_EMPTY, &diff, nil
 	}
 
-	if flowTypeObject.Flow == nil || len(flowTypeObject.Flow) > 1 {
-		return false
+	if flowTypeObject.Flow == nil {
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_NO_FLOW_DEF, nil, nil
+	}
+
+	if len(flowTypeObject.Flow) > 1 {
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_MULTIPLE_FLOW_DEF, nil, nil
 	}
 
 	for _, flow := range flowTypeObject.Flow {
-		if !validateRequiredFlowAttributes(flow, cmpOpts) {
-			return false
+		if ok, diff := validateRequiredFlowAttributes(flow, cmpOpts); !ok {
+			return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_REQUIRED_FLOW_DEF, diff, nil
 		}
 	}
 
@@ -66,50 +86,54 @@ func ValidFlowsInfoExport(data []byte, cmpOpts ExportCmpOpts) bool {
 			},
 		}
 
-		if ok := Equal(empty, flowTypeObject, ExportCmpOpts{
+		cmpOpts := ExportCmpOpts{
 			IgnoreConfig:              true,
 			IgnoreDesignerCues:        true,
 			IgnoreEnvironmentMetadata: true,
 			IgnoreFlowMetadata:        true,
 			IgnoreUnmappedProperties:  false,
 			IgnoreVersionMetadata:     true,
-		},
-			cmpopts.IgnoreFields(Elements{}, "Nodes"),
-		); !ok {
-			return false
+		}
+
+		opts := cmpopts.IgnoreFields(Elements{}, "Nodes")
+
+		if ok := Equal(empty, flowTypeObject, cmpOpts, opts); !ok {
+			diff := Diff(empty, flowTypeObject, cmpOpts, opts)
+			return false, ENUM_VALID_FLOW_OBJ_ERROR_UNKNOWN_ADDITIONAL_JSON_VALUES, &diff, nil
 		}
 	}
 
 	// TODO validate required struct attributes
-	return true
+	return true, ENUM_VALID_FLOW_OBJ_ERROR_NONE, nil, nil
 }
 
-func ValidFlowInfoExport(data []byte, cmpOpts ExportCmpOpts) bool {
+func ValidFlowInfoExport(data []byte, cmpOpts ExportCmpOpts) (ok bool, errorCode EnumValidFlowObjError, diff *string, err error) {
 	if ok := json.Valid(data); !ok {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_JSON, nil, nil
 	}
 
 	var flowTypeObject FlowInfo
 
 	if err := Unmarshal([]byte(data), &flowTypeObject, cmpOpts); err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_UNMARSHAL, nil, err
 	}
 
 	jsonBytes, err := Marshal(flowTypeObject, cmpOpts)
 	if err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_MARSHAL, nil, err
 	}
 
 	if string(jsonBytes) == "{}" {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_EMPTY_FLOW, nil, nil
 	}
 
 	if cmp.Equal(flowTypeObject, FlowInfo{}, cmpopts.EquateEmpty()) {
-		return false
+		diff := cmp.Diff(flowTypeObject, FlowInfo{}, cmpopts.EquateEmpty())
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_OBJECT_EQUATES_EMPTY, &diff, nil
 	}
 
-	if !validateRequiredFlowAttributes(flowTypeObject.Flow, cmpOpts) {
-		return false
+	if ok, diff := validateRequiredFlowAttributes(flowTypeObject.Flow, cmpOpts); !ok {
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_REQUIRED_FLOW_DEF, diff, nil
 	}
 
 	if !cmpOpts.IgnoreUnmappedProperties {
@@ -135,50 +159,54 @@ func ValidFlowInfoExport(data []byte, cmpOpts ExportCmpOpts) bool {
 			},
 		}
 
-		if ok := Equal(empty, flowTypeObject, ExportCmpOpts{
+		cmpOpts := ExportCmpOpts{
 			IgnoreConfig:              true,
 			IgnoreDesignerCues:        true,
 			IgnoreEnvironmentMetadata: true,
 			IgnoreUnmappedProperties:  false,
 			IgnoreVersionMetadata:     true,
 			IgnoreFlowMetadata:        true,
-		},
-			cmpopts.IgnoreFields(Elements{}, "Nodes"),
-		); !ok {
-			return false
+		}
+
+		opts := cmpopts.IgnoreFields(Elements{}, "Nodes")
+
+		if ok := Equal(empty, flowTypeObject, cmpOpts, opts); !ok {
+			diff := Diff(empty, flowTypeObject, cmpOpts, opts)
+			return false, ENUM_VALID_FLOW_OBJ_ERROR_UNKNOWN_ADDITIONAL_JSON_VALUES, &diff, nil
 		}
 	}
 
 	// TODO validate required struct attributes
-	return true
+	return true, ENUM_VALID_FLOW_OBJ_ERROR_NONE, nil, nil
 }
 
-func ValidFlowExport(data []byte, cmpOpts ExportCmpOpts) bool {
+func ValidFlowExport(data []byte, cmpOpts ExportCmpOpts) (ok bool, errorCode EnumValidFlowObjError, diff *string, err error) {
 	if ok := json.Valid(data); !ok {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_JSON, nil, nil
 	}
 
 	var flowTypeObject Flow
 
 	if err := Unmarshal([]byte(data), &flowTypeObject, cmpOpts); err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_UNMARSHAL, nil, err
 	}
 
 	jsonBytes, err := Marshal(flowTypeObject, cmpOpts)
 	if err != nil {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_CANNOT_DV_MARSHAL, nil, err
 	}
 
 	if string(jsonBytes) == "{}" {
-		return false
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_EMPTY_FLOW, nil, nil
 	}
 
 	if cmp.Equal(flowTypeObject, Flow{}, cmpopts.EquateEmpty()) {
-		return false
+		diff := cmp.Diff(flowTypeObject, Flow{}, cmpopts.EquateEmpty())
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_OBJECT_EQUATES_EMPTY, &diff, nil
 	}
 
-	if !validateRequiredFlowAttributes(flowTypeObject, cmpOpts) {
-		return false
+	if ok, diff := validateRequiredFlowAttributes(flowTypeObject, cmpOpts); !ok {
+		return false, ENUM_VALID_FLOW_OBJ_ERROR_INVALID_REQUIRED_FLOW_DEF, diff, nil
 	}
 
 	if !cmpOpts.IgnoreUnmappedProperties {
@@ -202,39 +230,58 @@ func ValidFlowExport(data []byte, cmpOpts ExportCmpOpts) bool {
 			},
 		}
 
-		if ok := Equal(empty, flowTypeObject, ExportCmpOpts{
+		cmpOpts := ExportCmpOpts{
 			IgnoreConfig:              true,
 			IgnoreDesignerCues:        true,
 			IgnoreEnvironmentMetadata: true,
 			IgnoreUnmappedProperties:  false,
 			IgnoreVersionMetadata:     true,
 			IgnoreFlowMetadata:        true,
-		},
-			cmpopts.IgnoreFields(Elements{}, "Nodes"),
-		); !ok {
-			return false
+			IgnoreFlowVariables:       true,
+		}
+
+		opts := cmpopts.IgnoreFields(Elements{}, "Nodes")
+
+		if ok := Equal(empty, flowTypeObject, cmpOpts, opts); !ok {
+			diff := Diff(empty, flowTypeObject, cmpOpts, opts)
+			return false, ENUM_VALID_FLOW_OBJ_ERROR_UNKNOWN_ADDITIONAL_JSON_VALUES, &diff, nil
 		}
 	}
 
 	// TODO validate required struct attributes
-	return true
+	return true, ENUM_VALID_FLOW_OBJ_ERROR_NONE, nil, nil
 }
 
-func ValidExport(data []byte, cmpOpts ExportCmpOpts) bool {
-	return ValidFlowExport(data, cmpOpts) || ValidFlowInfoExport(data, cmpOpts) || ValidFlowsInfoExport(data, cmpOpts)
+func ValidExport(data []byte, cmpOpts ExportCmpOpts) (ok bool, errorCode EnumValidFlowObjError, diff *string, err error) {
+
+	if ok, code, diff, err := ValidFlowExport(data, cmpOpts); !ok {
+		return ok, code, diff, err
+	}
+
+	if ok, code, diff, err := ValidFlowInfoExport(data, cmpOpts); !ok {
+		return ok, code, diff, err
+	}
+
+	if ok, code, diff, err := ValidFlowsInfoExport(data, cmpOpts); !ok {
+		return ok, code, diff, err
+	}
+
+	return true, ENUM_VALID_FLOW_OBJ_ERROR_NONE, nil, nil
 }
 
-func validateRequiredFlowAttributes(v Flow, opts ExportCmpOpts) bool {
+func validateRequiredFlowAttributes(v Flow, opts ExportCmpOpts) (ok bool, diff *string) {
 
 	if !opts.IgnoreConfig && cmp.Equal(v.FlowConfiguration, FlowConfiguration{}, cmpopts.EquateEmpty()) {
-		return false
+		diff := cmp.Diff(v.FlowConfiguration, FlowConfiguration{}, cmpopts.EquateEmpty())
+		return false, &diff
 	}
 
 	if !opts.IgnoreFlowMetadata && cmp.Equal(v.FlowMetadata, FlowMetadata{}, cmpopts.EquateEmpty()) {
-		return false
+		diff := cmp.Diff(v.FlowMetadata, FlowMetadata{}, cmpopts.EquateEmpty())
+		return false, &diff
 	}
 
 	// TODO - anything else to validate?
 
-	return true
+	return true, nil
 }

--- a/davinci/flow_valid_test.go
+++ b/davinci/flow_valid_test.go
@@ -2,6 +2,7 @@ package davinci_test
 
 import (
 	"io"
+	"log"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestValidFlowJSON(t *testing.T) {
 			t.Errorf("Failed to read file: %v", err)
 		}
 
-		if ok := davinci.ValidFlowExport(jsonBytes, davinci.ExportCmpOpts{
+		if ok, errorCode, diff, err := davinci.ValidFlowExport(jsonBytes, davinci.ExportCmpOpts{
 			IgnoreConfig:              true,
 			IgnoreDesignerCues:        true,
 			IgnoreEnvironmentMetadata: true,
@@ -32,6 +33,9 @@ func TestValidFlowJSON(t *testing.T) {
 			IgnoreVersionMetadata:     true,
 			IgnoreFlowMetadata:        true,
 		}); !ok {
+			log.Printf("Error Code: %v", errorCode)
+			log.Printf("Diff: %v", diff)
+			log.Printf("Error: %v", err)
 			t.Errorf("Expected: %v, Got: %v", false, ok)
 		}
 	})
@@ -50,7 +54,7 @@ func TestValidFlowJSON(t *testing.T) {
 			t.Errorf("Failed to read file: %v", err)
 		}
 
-		if ok := davinci.ValidFlowExport(jsonBytes, davinci.ExportCmpOpts{
+		if ok, errorCode, diff, err := davinci.ValidFlowExport(jsonBytes, davinci.ExportCmpOpts{
 			IgnoreConfig:              true,
 			IgnoreDesignerCues:        true,
 			IgnoreEnvironmentMetadata: true,
@@ -58,6 +62,9 @@ func TestValidFlowJSON(t *testing.T) {
 			IgnoreVersionMetadata:     true,
 			IgnoreFlowMetadata:        true,
 		}); ok {
+			log.Printf("Error Code: %v", errorCode)
+			log.Printf("Diff: %v", diff)
+			log.Printf("Error: %v", err)
 			t.Errorf("Expected: %v, Got: %v", true, ok)
 		}
 	})

--- a/davinci/flows.go
+++ b/davinci/flows.go
@@ -156,6 +156,13 @@ func (c *APIClient) ReadFlowVersion(companyId string, flowId string, flowVersion
 }
 
 func (c *APIClient) ReadFlowVersionWithResponse(companyId string, flowId string, flowVersion *string) (*FlowInfo, *http.Response, error) {
+	// prior to the new feature flows always returned variable values. So we default to true
+	return c.ReadFlowVersionOptionalVariableWithResponse(companyId, flowId, flowVersion, true)
+}
+
+// ReadFlowVersionOptionalVariableWithResponse is like ReadFlowVersionWithResponse
+// but also accepts option to include variable values
+func (c *APIClient) ReadFlowVersionOptionalVariableWithResponse(companyId string, flowId string, flowVersion *string, includeVariableValues bool) (*FlowInfo, *http.Response, error) {
 	if flowVersion == nil {
 		flow, res, err := c.ReadFlowWithResponse(companyId, flowId)
 		if err != nil || flow == nil || flow.Flow.CurrentVersion == nil {
@@ -168,7 +175,7 @@ func (c *APIClient) ReadFlowVersionWithResponse(companyId string, flowId string,
 
 	req := DvHttpRequest{
 		Method: "GET",
-		Url:    fmt.Sprintf("%s/flows/%s/versions/%s?includeSubflows=false", c.HostURL, flowId, *flowVersion),
+		Url:    fmt.Sprintf("%s/flows/%s/versions/%s?includeSubflows=false&includeVariableValues=%s", c.HostURL, flowId, *flowVersion, fmt.Sprint(includeVariableValues)),
 	}
 	body, res, err := c.doRequestRetryable(&companyId, req, nil)
 	if err != nil {

--- a/davinci/models_flow_variable.go
+++ b/davinci/models_flow_variable.go
@@ -5,6 +5,7 @@ import "encoding/json"
 type _FlowVariable FlowVariable
 type FlowVariable struct {
 	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	ID                   *string                `json:"id,omitempty" davinci:"id,environmentmetadata,omitempty"`
 	CompanyID            *string                `json:"companyId,omitempty" davinci:"companyId,environmentmetadata,omitempty"`
 	Context              *string                `json:"context,omitempty" davinci:"context,config,omitempty"`
 	CreatedDate          *EpochTime             `json:"createdDate,omitempty" davinci:"createdDate,flowvariables,omitempty"`
@@ -32,6 +33,7 @@ func (o FlowVariable) ToMap() (map[string]interface{}, error) {
 
 	result := map[string]interface{}{}
 
+	result["id"] = o.ID
 	result["companyId"] = o.CompanyID
 	result["context"] = o.Context
 	result["createdDate"] = o.CreatedDate
@@ -67,6 +69,7 @@ func (o *FlowVariable) UnmarshalJSON(bytes []byte) (err error) {
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
 		delete(additionalProperties, "companyId")
 		delete(additionalProperties, "context")
 		delete(additionalProperties, "createdDate")

--- a/davinci/models_flow_variable.go
+++ b/davinci/models_flow_variable.go
@@ -7,17 +7,17 @@ type FlowVariable struct {
 	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
 	CompanyID            *string                `json:"companyId,omitempty" davinci:"companyId,environmentmetadata,omitempty"`
 	Context              *string                `json:"context,omitempty" davinci:"context,config,omitempty"`
-	CreatedDate          *EpochTime             `json:"createdDate,omitempty" davinci:"createdDate,versionmetadata,omitempty"`
+	CreatedDate          *EpochTime             `json:"createdDate,omitempty" davinci:"createdDate,flowvariables,omitempty"`
 	CustomerID           *string                `json:"customerId,omitempty" davinci:"customerId,environmentmetadata,omitempty"`
 	Fields               *FlowVariableFields    `json:"fields,omitempty" davinci:"fields,*,omitempty"`
 	FlowID               *string                `json:"flowId,omitempty" davinci:"flowId,environmentmetadata,omitempty"`
 	Key                  *float64               `json:"key,omitempty" davinci:"key,flowmetadata,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
+	Label                *string                `json:"label,omitempty" davinci:"label,flowvariables,omitempty"`
 	Name                 string                 `json:"name" davinci:"name,config"`
 	Type                 string                 `json:"type" davinci:"type,config"`
-	UpdatedDate          *EpochTime             `json:"updatedDate,omitempty" davinci:"updatedDate,versionmetadata,omitempty"`
-	Value                *string                `json:"value,omitempty" davinci:"value,config,omitempty"`
-	Visibility           *string                `json:"visibility,omitempty" davinci:"visibility,flowmetadata,omitempty"`
+	UpdatedDate          *EpochTime             `json:"updatedDate,omitempty" davinci:"updatedDate,flowvariables,omitempty"`
+	Value                *string                `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
+	Visibility           *string                `json:"visibility,omitempty" davinci:"visibility,flowvariables,omitempty"`
 }
 
 func (o FlowVariable) MarshalJSON() ([]byte, error) {

--- a/davinci/models_flow_variable_fields.go
+++ b/davinci/models_flow_variable_fields.go
@@ -6,11 +6,11 @@ type _FlowVariableFields FlowVariableFields
 type FlowVariableFields struct {
 	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
 	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
-	DisplayName          *string                `json:"displayName,omitempty" davinci:"displayName,config,omitempty"`
-	Mutable              *bool                  `json:"mutable,omitempty" davinci:"mutable,config,omitempty"`
-	Value                *string                `json:"value,omitempty" davinci:"value,config,omitempty"`
-	Min                  *int32                 `json:"min,omitempty" davinci:"min,config,omitempty"`
-	Max                  *int32                 `json:"max,omitempty" davinci:"max,config,omitempty"`
+	DisplayName          *string                `json:"displayName,omitempty" davinci:"displayName,flowvariables,omitempty"`
+	Mutable              *bool                  `json:"mutable,omitempty" davinci:"mutable,flowvariables,omitempty"`
+	Value                *string                `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
+	Min                  *int32                 `json:"min,omitempty" davinci:"min,flowvariables,omitempty"`
+	Max                  *int32                 `json:"max,omitempty" davinci:"max,flowvariables,omitempty"`
 }
 
 func (o FlowVariableFields) MarshalJSON() ([]byte, error) {

--- a/davinci/models_properties.go
+++ b/davinci/models_properties.go
@@ -8,7 +8,8 @@ type Properties struct {
 	Form                 *string                `json:"form,omitempty" davinci:"form,config,omitempty"`
 	SubFlowID            *SubFlowID             `json:"subFlowId,omitempty" davinci:"subFlowId,config,omitempty"`
 	SubFlowVersionID     *SubFlowVersionID      `json:"subFlowVersionId,omitempty" davinci:"subFlowVersionId,config,omitempty"`
-	SaveFlowVariables    *SaveFlowVariables     `json:"saveFlowVariables,omitempty" davinci:"saveFlowVariables,config,omitempty"`
+	SaveFlowVariables    *SaveFlowVariables     `json:"saveFlowVariables,omitempty" davinci:"saveFlowVariables,*,omitempty"`
+	SaveVariables        *SaveFlowVariables     `json:"saveVariables,omitempty" davinci:"saveVariables,*,omitempty"`
 }
 
 func (o Properties) MarshalJSON() ([]byte, error) {
@@ -39,6 +40,10 @@ func (o Properties) ToMap() (map[string]interface{}, error) {
 		result["saveFlowVariables"] = o.SaveFlowVariables
 	}
 
+	if o.SaveVariables != nil {
+		result["saveVariables"] = o.SaveVariables
+	}
+
 	for k, v := range o.AdditionalProperties {
 		result[k] = v
 	}
@@ -60,6 +65,7 @@ func (o *Properties) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "subFlowId")
 		delete(additionalProperties, "subFlowVersionId")
 		delete(additionalProperties, "saveFlowVariables")
+		delete(additionalProperties, "saveVariables")
 		o.AdditionalProperties = additionalProperties
 	}
 


### PR DESCRIPTION
## Changes

- Added ability to filter out variable properties from a DaVinci flow struct object
- Added additional context for clients as to why a flow fails validation (added debug logging to TF provider)
- Add `ID` to `FlowVariable` model to resolve unexpected flow properties warning in TF provider
- Supports exporting flows without variable values
- Fix API function to retrieve a single variable by name/ID