### PR TITLE
Update flow definition 20240827

### DIFF
--- a/davinci/flow_valid.go
+++ b/davinci/flow_valid.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	ErrInvalidJson = errors.New("Invalid JSON")
-	ErrEmptyFlow = errors.New("Flow JSON is empty")
-	ErrNoFlowDefinition = errors.New("No flow definition found in flow export array. Expecting exactly one flow definition")
+	ErrInvalidJson               = errors.New("Invalid JSON")
+	ErrEmptyFlow                 = errors.New("Flow JSON is empty")
+	ErrNoFlowDefinition          = errors.New("No flow definition found in flow export array. Expecting exactly one flow definition")
 	ErrMissingSaveVariableValues = errors.New("Save flow variable nodes present but missing variable values")
 )
 
@@ -237,6 +237,107 @@ func ValidFlowInfoExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 	return nil
 }
 
+func ValidFlowsExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
+	if ok := json.Valid(data); !ok {
+		return ErrInvalidJson
+	}
+
+	var flowTypeObject Flows
+
+	if err := Unmarshal([]byte(data), &flowTypeObject, cmpOpts); err != nil {
+		return err
+	}
+
+	jsonBytes, err := Marshal(flowTypeObject, cmpOpts)
+	if err != nil {
+		return err
+	}
+
+	if string(jsonBytes) == "{}" {
+		return ErrEmptyFlow
+	}
+
+	if cmp.Equal(flowTypeObject, Flows{}, cmpopts.EquateEmpty()) {
+		diff := cmp.Diff(flowTypeObject, Flows{}, cmpopts.EquateEmpty())
+		return &EquatesEmptyTypeError{
+			Diff: diff,
+		}
+	}
+
+	if flowTypeObject.Flow == nil {
+		return ErrNoFlowDefinition
+	}
+
+	if cmpOpts.MaxFlows != nil && len(flowTypeObject.Flow) > *cmpOpts.MaxFlows {
+		return &MaxFlowDefinitionsExceededTypeError{
+			Max: *cmpOpts.MaxFlows,
+		}
+	}
+
+	if cmpOpts.MinFlows != nil && len(flowTypeObject.Flow) < *cmpOpts.MinFlows {
+		return &MinFlowDefinitionsExceededTypeError{
+			Min: *cmpOpts.MinFlows,
+		}
+	}
+
+	for _, flow := range flowTypeObject.Flow {
+		if err := validateRequiredFlowAttributes(flow, cmpOpts); err != nil {
+			return err
+		}
+		if err := validateVariableValues(flow, cmpOpts); err != nil {
+			return err
+		}
+	}
+
+	if !cmpOpts.IgnoreUnmappedProperties {
+		empty := Flows{
+			Flow: []Flow{
+				{
+					FlowConfiguration: FlowConfiguration{
+						FlowUpdateConfiguration: FlowUpdateConfiguration{
+							GraphData: &GraphData{
+								Elements: &Elements{
+									Nodes: []Node{
+										{
+											Data: &NodeData{
+												AdditionalProperties: map[string]interface{}{
+													"test1": "test1", // to overcome odd behaviours with cmpopts
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		cmpOpts := ExportCmpOpts{
+			IgnoreConfig:              true,
+			IgnoreDesignerCues:        true,
+			IgnoreEnvironmentMetadata: true,
+			IgnoreFlowMetadata:        true,
+			IgnoreUnmappedProperties:  false,
+			IgnoreVersionMetadata:     true,
+			IgnoreFlowVariables:       true,
+		}
+
+		opts := cmpopts.IgnoreFields(Elements{}, "Nodes")
+
+		if ok := Equal(empty, flowTypeObject, cmpOpts, opts); !ok {
+			diff := Diff(empty, flowTypeObject, cmpOpts, opts)
+			return &UnknownAdditionalFieldsTypeError{
+				Diff: diff,
+			}
+		}
+	}
+
+	// TODO validate required struct attributes
+	return nil
+}
+
 func ValidFlowExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 	if ok := json.Valid(data); !ok {
 		return ErrInvalidJson
@@ -358,7 +459,7 @@ func validateRequiredFlowAttributes(v Flow, opts ExportCmpOpts) error {
 func validateVariableValues(v Flow, opts ExportCmpOpts) error {
 
 	if opts.NodeOpts != nil && opts.NodeOpts.VariablesConnector != nil && opts.NodeOpts.VariablesConnector.ExpectVariableValues {
-		
+
 		// If there are no variable nodes, return true
 		if v.FlowConfiguration.GraphData == nil || v.FlowConfiguration.GraphData.Elements == nil || v.FlowConfiguration.GraphData.Elements.Nodes == nil || len(v.FlowConfiguration.GraphData.Elements.Nodes) == 0 {
 			return nil

--- a/davinci/models_flow.go
+++ b/davinci/models_flow.go
@@ -25,10 +25,11 @@ type FlowUpdateConfiguration struct {
 }
 
 type FlowEnvironmentMetadata struct {
-	CompanyID   string    `json:"companyId" davinci:"companyId,environmentmetadata"`
-	CreatedDate EpochTime `json:"createdDate" davinci:"createdDate,environmentmetadata"`
-	CustomerID  string    `json:"customerId" davinci:"customerId,environmentmetadata"`
-	FlowID      string    `json:"flowId" davinci:"flowId,environmentmetadata"`
+	CompanyID    string    `json:"companyId" davinci:"companyId,environmentmetadata"`
+	CreatedDate  EpochTime `json:"createdDate" davinci:"createdDate,environmentmetadata"`
+	CustomerID   string    `json:"customerId" davinci:"customerId,environmentmetadata"`
+	FlowID       string    `json:"flowId" davinci:"flowId,environmentmetadata"`
+	ParentFlowID *string   `json:"parentFlowId,omitempty" davinci:"parentFlowId,environmentmetadata,omitempty"`
 }
 
 type FlowMetadata struct {
@@ -97,6 +98,7 @@ func (o *Flow) UnmarshalDavinci(bytes []byte, opts ExportCmpOpts) (err error) {
 	delete(additionalProperties, "orx")
 	delete(additionalProperties, "outputSchema")
 	delete(additionalProperties, "outputSchemaCompiled")
+	delete(additionalProperties, "parentFlowId")
 	delete(additionalProperties, "publishedVersion")
 	delete(additionalProperties, "savedDate")
 	delete(additionalProperties, "settings")
@@ -159,6 +161,11 @@ func (o Flow) ToMap() (map[string]interface{}, error) {
 	}
 
 	result["flowId"] = o.FlowID
+
+	if o.ParentFlowID != nil {
+		result["parentFlowId"] = o.ParentFlowID
+	}
+
 	result["flowStatus"] = o.FlowStatus
 
 	if o.FunctionConnectionID != nil {
@@ -265,6 +272,7 @@ func (o *Flow) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "orx")
 		delete(additionalProperties, "outputSchema")
 		delete(additionalProperties, "outputSchemaCompiled")
+		delete(additionalProperties, "parentFlowId")
 		delete(additionalProperties, "publishedVersion")
 		delete(additionalProperties, "savedDate")
 		delete(additionalProperties, "settings")

--- a/davinci/models_flow_variable_fields.go
+++ b/davinci/models_flow_variable_fields.go
@@ -8,7 +8,7 @@ type FlowVariableFields struct {
 	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
 	DisplayName          *string                `json:"displayName,omitempty" davinci:"displayName,flowvariables,omitempty"`
 	Mutable              *bool                  `json:"mutable,omitempty" davinci:"mutable,flowvariables,omitempty"`
-	Value                *string                `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
+	Value                interface{}            `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
 	Min                  *int32                 `json:"min,omitempty" davinci:"min,flowvariables,omitempty"`
 	Max                  *int32                 `json:"max,omitempty" davinci:"max,flowvariables,omitempty"`
 }

--- a/davinci/models_sub_flow_version_id_value.go
+++ b/davinci/models_sub_flow_version_id_value.go
@@ -75,17 +75,17 @@ func (o *SubFlowVersionIDValue) unmarshal(bytes []byte) (err error) {
 	}
 
 	if !match {
-		// try to unmarshal data into ValueFloat64
-		err = newStrictDecoder(bytes).Decode(&o.ValueFloat64)
+		// try to unmarshal data into ValueString
+		err = newStrictDecoder(bytes).Decode(&o.ValueString)
 		if err == nil {
-			jsonValueFloat64, _ := json.Marshal(o.ValueFloat64)
-			if string(jsonValueFloat64) == "{}" { // empty struct
-				o.ValueFloat64 = nil
+			jsonValueString, _ := json.Marshal(o.ValueString)
+			if string(jsonValueString) == "{}" { // empty struct
+				o.ValueString = nil
 			} else {
 				match = true
 			}
 		} else {
-			o.ValueFloat64 = nil
+			o.ValueString = nil
 		}
 	}
 


### PR DESCRIPTION
- Add `ValidFlowsExport` to verify multi-flow exports
- Fix bug unmarshalling Sub flow version ID values where the value is a string
- Add previously untracked `parentFlowId` field to the `Flow` model