### PR TITLE
Update flow settings data model

### DIFF
--- a/davinci/applications_test.go
+++ b/davinci/applications_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/samir-gandhi/davinci-client-go/davinci"
 )
 
-var testDataApps = map[string]interface{}{
+var testDataApps = map[string]any{
 	"params": map[string]davinci.Params{
 		"a": {
 			Page:  "0",

--- a/davinci/codec_map.go
+++ b/davinci/codec_map.go
@@ -37,7 +37,7 @@ func (d MapCodec) DecodeValue(data []byte, v reflect.Value) error {
 	}
 
 	// Unmarshal the data into a map
-	var tempMap map[string]interface{}
+	var tempMap map[string]any
 	if err := json.Unmarshal(data, &tempMap); err != nil {
 		return err
 	}

--- a/davinci/codec_struct.go
+++ b/davinci/codec_struct.go
@@ -41,8 +41,8 @@ func (d StructCodec) DecodeValue(data []byte, v reflect.Value) error {
 
 	typ := v.Type()
 
-	// Unmarshal the data into a map[string]interface{} to work with.
-	var tempMap map[string]interface{}
+	// Unmarshal the data into a map[string]any to work with.
+	var tempMap map[string]any
 	if err := json.Unmarshal(data, &tempMap); err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (d StructCodec) DecodeValue(data []byte, v reflect.Value) error {
 			}
 
 			if field.Kind() != reflect.Map || field.Type().Key().Kind() != reflect.String || field.Type().Elem().Kind() != reflect.Interface {
-				return fmt.Errorf("field with purpose 'unmappedproperties' must be a map[string]interface{}")
+				return fmt.Errorf("field with purpose 'unmappedproperties' must be a map[string]any")
 			}
 
 			unmappedPropertiesField = field
@@ -157,15 +157,15 @@ func (d StructCodec) EncodeValue(v reflect.Value) ([]byte, error) {
 	// Convert the JSON object to a byte slice
 	resultBytes := []byte(result)
 
-	// Unmarshal the data into a map[string]interface{} to work with.
-	var tempMap map[string]interface{}
+	// Unmarshal the data into a map[string]any to work with.
+	var tempMap map[string]any
 	if err := json.Unmarshal(resultBytes, &tempMap); err != nil {
 		return nil, err
 	}
 
 	//Deal with additional / unmapped properties
 	if !d.eCtx.Opts.IgnoreUnmappedProperties && unmappedPropertiesField.Kind() != reflect.Invalid {
-		for k, v := range unmappedPropertiesField.Interface().(map[string]interface{}) {
+		for k, v := range unmappedPropertiesField.Interface().(map[string]any) {
 			tempMap[k] = v
 		}
 	}
@@ -221,7 +221,7 @@ func (d StructCodec) encodePartValue(v reflect.Value, unmappedPropertiesField *r
 			}
 
 			if field.Kind() != reflect.Map || field.Type().Key().Kind() != reflect.String || field.Type().Elem().Kind() != reflect.Interface {
-				return nil, fmt.Errorf("field with purpose 'unmappedproperties' must be a map[string]interface{}")
+				return nil, fmt.Errorf("field with purpose 'unmappedproperties' must be a map[string]any")
 			}
 
 			*unmappedPropertiesField = field

--- a/davinci/connections_test.go
+++ b/davinci/connections_test.go
@@ -29,7 +29,7 @@ func RandString(n int) string {
 // 	} `json:"envId`
 // }
 
-var testDataConnections = map[string]interface{}{
+var testDataConnections = map[string]any{
 	"params": map[string]davinci.Params{
 		"a": {"1", "10", nil},
 		"b": {"1000", "10", nil},

--- a/davinci/flow_equality_test.go
+++ b/davinci/flow_equality_test.go
@@ -51,8 +51,10 @@ func TestEqual_Basic(t *testing.T) {
 		"not-equal-added-attribute": {
 			parentObject: func() davinci.Flow {
 				r := test.Data_FullBasic()
-				r.Settings = map[string]interface{}{
-					"new-key": "new-value",
+				r.Settings = &davinci.FlowSettings{
+					AdditionalProperties: map[string]any{
+						"new-key": "new-value",
+					},
 				}
 				return r
 			}(),
@@ -84,7 +86,7 @@ func TestEqual_UnmappedPropertiesOption(t *testing.T) {
 			parentObject: test.Data_FullBasic(),
 			compareObject: func() davinci.Flow {
 				r := test.Data_FullBasic()
-				r.AdditionalProperties = map[string]interface{}{
+				r.AdditionalProperties = map[string]any{
 					"modified-key": "modified-key-value",
 				}
 				return r
@@ -101,7 +103,7 @@ func TestEqual_UnmappedPropertiesOption(t *testing.T) {
 			parentObject: test.Data_FullBasic(),
 			compareObject: func() davinci.Flow {
 				r := test.Data_FullBasic()
-				r.AdditionalProperties = map[string]interface{}{
+				r.AdditionalProperties = map[string]any{
 					"modified-key": "modified-key-value",
 				}
 				return r
@@ -166,7 +168,7 @@ func TestEqual_UnmappedPropertiesOption(t *testing.T) {
 			parentObject: test.Data_FullBasic(),
 			compareObject: func() davinci.Flow {
 				r := test.Data_FullBasic()
-				r.GraphData.AdditionalProperties = map[string]interface{}{
+				r.GraphData.AdditionalProperties = map[string]any{
 					"modified-key": "modified-key-value",
 				}
 				return r
@@ -183,7 +185,7 @@ func TestEqual_UnmappedPropertiesOption(t *testing.T) {
 			parentObject: test.Data_FullBasic(),
 			compareObject: func() davinci.Flow {
 				r := test.Data_FullBasic()
-				r.GraphData.AdditionalProperties = map[string]interface{}{
+				r.GraphData.AdditionalProperties = map[string]any{
 					"modified-key": "modified-key-value",
 				}
 				return r

--- a/davinci/flow_valid.go
+++ b/davinci/flow_valid.go
@@ -117,7 +117,7 @@ func ValidFlowsInfoExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 									Nodes: []Node{
 										{
 											Data: &NodeData{
-												AdditionalProperties: map[string]interface{}{
+												AdditionalProperties: map[string]any{
 													"test1": "test1", // to overcome odd behaviours with cmpopts
 												},
 											},
@@ -200,7 +200,7 @@ func ValidFlowInfoExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 								Nodes: []Node{
 									{
 										Data: &NodeData{
-											AdditionalProperties: map[string]interface{}{
+											AdditionalProperties: map[string]any{
 												"test1": "test1", // to overcome odd behaviours with cmpopts
 											},
 										},
@@ -300,7 +300,7 @@ func ValidFlowsExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 									Nodes: []Node{
 										{
 											Data: &NodeData{
-												AdditionalProperties: map[string]interface{}{
+												AdditionalProperties: map[string]any{
 													"test1": "test1", // to overcome odd behaviours with cmpopts
 												},
 											},
@@ -382,7 +382,7 @@ func ValidFlowExport(data []byte, cmpOpts ExportCmpOpts) (err error) {
 							Nodes: []Node{
 								{
 									Data: &NodeData{
-										AdditionalProperties: map[string]interface{}{
+										AdditionalProperties: map[string]any{
 											"test1": "test1", // to overcome odd behaviours with cmpopts
 										},
 									},

--- a/davinci/flows_test.go
+++ b/davinci/flows_test.go
@@ -22,7 +22,7 @@ import (
  */
 
 // testData for Roles functions
-var testDataFlows = map[string]interface{}{
+var testDataFlows = map[string]any{
 	"params": map[string]davinci.Params{
 		"limitTen": {Limit: "10"},
 		"limitTwo": {Limit: "2"},
@@ -31,7 +31,7 @@ var testDataFlows = map[string]interface{}{
 		"pageNeg": {Page: "2"},
 	},
 	// "flowsCreate": Flow{
-	// 	AdditionalProperties: map[string]interface{}{
+	// 	AdditionalProperties: map[string]any{
 	// 		"custom-unimplemented-1": "custom-unimplemented-1",
 	// 		"custom-unimplemented-2": "custom-unimplemented-2",
 	// 	},
@@ -62,7 +62,7 @@ var testDataFlows = map[string]interface{}{
 	// 		GraphData:            GraphData{},
 	// 	},
 	// },
-	"flowsCreateJson": map[string]interface{}{
+	"flowsCreateJson": map[string]any{
 		"properImport": func() string {
 			v, err := test.ReadJsonFile("flows/flows-create-1.json")
 			if err != nil {
@@ -103,7 +103,7 @@ func TestFlows_Read(t *testing.T) {
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
 
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {
@@ -160,7 +160,7 @@ func TestFlow_Create(t *testing.T) {
 		panic(err)
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestFlow_CreateWithJson(t *testing.T) {
 		panic(err)
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestFlow_Update(t *testing.T) {
 		panic(err)
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {
@@ -313,7 +313,7 @@ func TestFlow_Delete(t *testing.T) {
 		panic(err)
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {
@@ -356,7 +356,7 @@ func TestFlow_Deploy(t *testing.T) {
 		panic(err)
 	}
 	companyID := os.Getenv("PINGONE_TARGET_ENVIRONMENT_ID")
-	if args, ok := testDataFlows["flowsCreateJson"].(map[string]interface{}); ok {
+	if args, ok := testDataFlows["flowsCreateJson"].(map[string]any); ok {
 		for i, thisArg := range args {
 			testName := i
 			t.Run(testName, func(t *testing.T) {

--- a/davinci/marshal_test.go
+++ b/davinci/marshal_test.go
@@ -80,7 +80,7 @@ func TestMarshal_AdditionalProperties(t *testing.T) {
 		y := float64(50)
 
 		newObj := davinci.Position{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -105,7 +105,7 @@ func TestMarshal_AdditionalProperties(t *testing.T) {
 		y := float64(50)
 
 		newObj := davinci.Position{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -181,7 +181,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 			CompanyID: &companyId,
 			Context:   &context,
 			Fields: &davinci.FlowVariableFields{
-				AdditionalProperties: map[string]interface{}{
+				AdditionalProperties: map[string]any{
 					"custom-attribute-1": "custom-value-1",
 					"custom-attribute-2": "custom-value-2",
 				},
@@ -211,7 +211,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 		jsonString := `{"custom-attribute-1":"custom-value-1","custom-attribute-2":"custom-value-2","fields":{"custom-attribute-1":"custom-sub-value-1","custom-attribute-2":"custom-sub-value-2"}}`
 
 		newObj := davinci.FlowVariable{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -220,7 +220,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 			CompanyID: &companyId,
 			Context:   &context,
 			Fields: &davinci.FlowVariableFields{
-				AdditionalProperties: map[string]interface{}{
+				AdditionalProperties: map[string]any{
 					"custom-attribute-1": "custom-sub-value-1",
 					"custom-attribute-2": "custom-sub-value-2",
 				},
@@ -279,7 +279,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 	}
 
 // 	expectedObj := TestModel{
-// 		AdditionalProperties: map[string]interface{}{
+// 		AdditionalProperties: map[string]any{
 // 			"custom-attribute-1": "custom-value-1",
 // 			"custom-attribute-2": "custom-value-2",
 // 		},
@@ -289,7 +289,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		Test4: func() *string { s := "test4Value"; return &s }(),
 // 		Test5: func() *TestModel2 {
 // 			s := TestModel2{
-// 				AdditionalProperties: map[string]interface{}{
+// 				AdditionalProperties: map[string]any{
 // 					"custom-attribute-1": "custom-value-1",
 // 					"custom-attribute-2": "custom-value-2",
 // 				},
@@ -347,7 +347,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		}
 
 // 		expectedObj := TestModel{
-// 			AdditionalProperties: map[string]interface{}{
+// 			AdditionalProperties: map[string]any{
 // 				"custom-attribute-1": "custom-value-1",
 // 				"custom-attribute-2": "custom-value-2",
 // 			},
@@ -357,7 +357,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 			Test4: func() *string { s := "test4Value"; return &s }(),
 // 			Test5: func() *TestModel2 {
 // 				s := TestModel2{
-// 					AdditionalProperties: map[string]interface{}{
+// 					AdditionalProperties: map[string]any{
 // 						"custom-attribute-1": "custom-value-1",
 // 						"custom-attribute-2": "custom-value-2",
 // 					},
@@ -415,7 +415,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		}
 
 // 		expectedObj := TestModel{
-// 			AdditionalProperties: map[string]interface{}{
+// 			AdditionalProperties: map[string]any{
 // 				"custom-attribute-1": "custom-value-1",
 // 				"custom-attribute-2": "custom-value-2",
 // 			},
@@ -425,7 +425,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 			//Test4: func() *string { s := "test4Value"; return &s }(),
 // 			Test5: func() *TestModel2 {
 // 				s := TestModel2{
-// 					AdditionalProperties: map[string]interface{}{
+// 					AdditionalProperties: map[string]any{
 // 						"custom-attribute-1": "custom-value-1",
 // 						"custom-attribute-2": "custom-value-2",
 // 					},
@@ -483,7 +483,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		}
 
 // 		expectedObj := TestModel{
-// 			//AdditionalProperties: map[string]interface{}{
+// 			//AdditionalProperties: map[string]any{
 // 			//	"custom-attribute-1": "custom-value-1",
 // 			//	"custom-attribute-2": "custom-value-2",
 // 			//},
@@ -493,7 +493,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 			Test4: func() *string { s := "test4Value"; return &s }(),
 // 			Test5: func() *TestModel2 {
 // 				s := TestModel2{
-// 					// AdditionalProperties: map[string]interface{}{
+// 					// AdditionalProperties: map[string]any{
 // 					// 	"custom-attribute-1": "custom-value-1",
 // 					// 	"custom-attribute-2": "custom-value-2",
 // 					// },
@@ -551,7 +551,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		}
 
 // 		expectedObj := TestModel{
-// 			AdditionalProperties: map[string]interface{}{
+// 			AdditionalProperties: map[string]any{
 // 				"custom-attribute-1": "custom-value-1",
 // 				"custom-attribute-2": "custom-value-2",
 // 			},
@@ -561,7 +561,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 			Test4: func() *string { s := "test4Value"; return &s }(),
 // 			Test5: func() *TestModel2 {
 // 				s := TestModel2{
-// 					AdditionalProperties: map[string]interface{}{
+// 					AdditionalProperties: map[string]any{
 // 						"custom-attribute-1": "custom-value-1",
 // 						"custom-attribute-2": "custom-value-2",
 // 					},
@@ -619,7 +619,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 		}
 
 // 		expectedObj := TestModel{
-// 			AdditionalProperties: map[string]interface{}{
+// 			AdditionalProperties: map[string]any{
 // 				"custom-attribute-1": "custom-value-1",
 // 				"custom-attribute-2": "custom-value-2",
 // 			},
@@ -629,7 +629,7 @@ func TestMarshal_Nested_AdditionalProperties(t *testing.T) {
 // 			Test4: func() *string { s := "test4Value"; return &s }(),
 // 			Test5: func() *TestModel2 {
 // 				s := TestModel2{
-// 					AdditionalProperties: map[string]interface{}{
+// 					AdditionalProperties: map[string]any{
 // 						"custom-attribute-1": "custom-value-1",
 // 						"custom-attribute-2": "custom-value-2",
 // 					},

--- a/davinci/models_connection.go
+++ b/davinci/models_connection.go
@@ -1,10 +1,13 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Connection Connection
 type Connection struct {
-	AdditionalProperties map[string]interface{}        `json:"additionalProperties,omitempty"`
+	AdditionalProperties map[string]any                `json:"additionalProperties,omitempty"`
 	CustomerID           *string                       `json:"customerId,omitempty"`
 	ConnectorID          *string                       `json:"connectorId,omitempty"`
 	Name                 *string                       `json:"name,omitempty"`
@@ -23,9 +26,9 @@ func (o Connection) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Connection) ToMap() (map[string]interface{}, error) {
+func (o Connection) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.CustomerID != nil {
 		result["customerId"] = o.CustomerID
@@ -59,9 +62,7 @@ func (o Connection) ToMap() (map[string]interface{}, error) {
 		result["companyId"] = o.CompanyID
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -73,7 +74,7 @@ func (o *Connection) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Connection(varConnection)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "customerId")

--- a/davinci/models_connection_property.go
+++ b/davinci/models_connection_property.go
@@ -1,10 +1,13 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _ConnectionProperty ConnectionProperty
 type ConnectionProperty struct {
-	AdditionalProperties map[string]interface{}        `json:"additionalProperties,omitempty"`
+	AdditionalProperties map[string]any                `json:"additionalProperties,omitempty"`
 	CompanyId            *string                       `json:"companyId,omitempty"`
 	ConstructItems       []string                      `json:"constructItems,omitempty"`
 	CreatedDate          *EpochTime                    `json:"createdDate,omitempty"`
@@ -29,9 +32,9 @@ func (o ConnectionProperty) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o ConnectionProperty) ToMap() (map[string]interface{}, error) {
+func (o ConnectionProperty) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.CompanyId != nil {
 		result["companyId"] = o.CompanyId
@@ -89,9 +92,7 @@ func (o ConnectionProperty) ToMap() (map[string]interface{}, error) {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -103,7 +104,7 @@ func (o *ConnectionProperty) UnmarshalJSON(bytes []byte) (err error) {
 		*o = ConnectionProperty(varConnectionProperty)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "companyId")

--- a/davinci/models_data.go
+++ b/davinci/models_data.go
@@ -1,23 +1,26 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Data Data
 type Data struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	CapabilityName       *string                `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
-	ConnectionID         *string                `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
-	ConnectorID          *string                `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
-	ID                   *string                `json:"id,omitempty" davinci:"id,config,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
-	MultiValueSourceId   *string                `json:"multiValueSourceId,omitempty" davinci:"multiValueSourceId,config,omitempty"`
-	Name                 *string                `json:"name,omitempty" davinci:"name,config,omitempty"`
-	NodeType             *string                `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
-	Properties           *Properties            `json:"properties" davinci:"properties,*"`
-	Source               *string                `json:"source,omitempty" davinci:"source,config,omitempty"`
-	Status               *string                `json:"status,omitempty" davinci:"status,config,omitempty"`
-	Target               *string                `json:"target,omitempty" davinci:"target,config,omitempty"`
-	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	CapabilityName       *string        `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
+	ConnectionID         *string        `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
+	ConnectorID          *string        `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
+	ID                   *string        `json:"id,omitempty" davinci:"id,config,omitempty"`
+	Label                *string        `json:"label,omitempty" davinci:"label,config,omitempty"`
+	MultiValueSourceId   *string        `json:"multiValueSourceId,omitempty" davinci:"multiValueSourceId,config,omitempty"`
+	Name                 *string        `json:"name,omitempty" davinci:"name,config,omitempty"`
+	NodeType             *string        `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
+	Properties           *Properties    `json:"properties" davinci:"properties,*"`
+	Source               *string        `json:"source,omitempty" davinci:"source,config,omitempty"`
+	Status               *string        `json:"status,omitempty" davinci:"status,config,omitempty"`
+	Target               *string        `json:"target,omitempty" davinci:"target,config,omitempty"`
+	Type                 *string        `json:"type,omitempty" davinci:"type,config,omitempty"`
 }
 
 func (o Data) MarshalJSON() ([]byte, error) {
@@ -28,9 +31,9 @@ func (o Data) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Data) ToMap() (map[string]interface{}, error) {
+func (o Data) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.CapabilityName != nil {
 		result["capabilityName"] = o.CapabilityName
@@ -84,9 +87,7 @@ func (o Data) ToMap() (map[string]interface{}, error) {
 		result["type"] = o.Type
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -98,7 +99,7 @@ func (o *Data) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Data(varData)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "capabilityName")

--- a/davinci/models_edge.go
+++ b/davinci/models_edge.go
@@ -1,20 +1,23 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Edge Edge
 type Edge struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Data                 *Data                  `json:"data,omitempty" davinci:"data,*,omitempty"`
-	Position             *Position              `json:"position,omitempty" davinci:"position,*,omitempty"`
-	Group                *string                `json:"group,omitempty" davinci:"group,designercue,omitempty"`
-	Removed              *bool                  `json:"removed,omitempty" davinci:"removed,designercue,omitempty"`
-	Selected             *bool                  `json:"selected,omitempty" davinci:"selected,designercue,omitempty"`
-	Selectable           *bool                  `json:"selectable,omitempty" davinci:"selectable,designercue,omitempty"`
-	Locked               *bool                  `json:"locked,omitempty" davinci:"locked,designercue,omitempty"`
-	Grabbable            *bool                  `json:"grabbable,omitempty" davinci:"grabbable,designercue,omitempty"`
-	Pannable             *bool                  `json:"pannable,omitempty" davinci:"pannable,designercue,omitempty"`
-	Classes              *string                `json:"classes,omitempty" davinci:"classes,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Data                 *Data          `json:"data,omitempty" davinci:"data,*,omitempty"`
+	Position             *Position      `json:"position,omitempty" davinci:"position,*,omitempty"`
+	Group                *string        `json:"group,omitempty" davinci:"group,designercue,omitempty"`
+	Removed              *bool          `json:"removed,omitempty" davinci:"removed,designercue,omitempty"`
+	Selected             *bool          `json:"selected,omitempty" davinci:"selected,designercue,omitempty"`
+	Selectable           *bool          `json:"selectable,omitempty" davinci:"selectable,designercue,omitempty"`
+	Locked               *bool          `json:"locked,omitempty" davinci:"locked,designercue,omitempty"`
+	Grabbable            *bool          `json:"grabbable,omitempty" davinci:"grabbable,designercue,omitempty"`
+	Pannable             *bool          `json:"pannable,omitempty" davinci:"pannable,designercue,omitempty"`
+	Classes              *string        `json:"classes,omitempty" davinci:"classes,config,omitempty"`
 }
 
 func (o Edge) MarshalJSON() ([]byte, error) {
@@ -25,9 +28,9 @@ func (o Edge) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Edge) ToMap() (map[string]interface{}, error) {
+func (o Edge) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Data != nil {
 		result["data"] = o.Data
@@ -69,9 +72,7 @@ func (o Edge) ToMap() (map[string]interface{}, error) {
 		result["classes"] = o.Classes
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -83,7 +84,7 @@ func (o *Edge) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Edge(varEdge)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "data")

--- a/davinci/models_edge_data.go
+++ b/davinci/models_edge_data.go
@@ -1,23 +1,26 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _EdgeData EdgeData
 type EdgeData struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	CapabilityName       *string                `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
-	ConnectionID         *string                `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
-	ConnectorID          *string                `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
-	ID                   *string                `json:"id,omitempty" davinci:"id,config,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
-	MultiValueSourceId   *string                `json:"multiValueSourceId,omitempty" davinci:"multiValueSourceId,config,omitempty"`
-	Name                 *string                `json:"name,omitempty" davinci:"name,config,omitempty"`
-	NodeType             *string                `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
-	Properties           *Properties            `json:"properties,omitempty" davinci:"properties,*,omitempty"`
-	Source               *string                `json:"source,omitempty" davinci:"source,config,omitempty"`
-	Status               *string                `json:"status,omitempty" davinci:"status,config,omitempty"`
-	Target               *string                `json:"target,omitempty" davinci:"target,config,omitempty"`
-	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	CapabilityName       *string        `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
+	ConnectionID         *string        `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
+	ConnectorID          *string        `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
+	ID                   *string        `json:"id,omitempty" davinci:"id,config,omitempty"`
+	Label                *string        `json:"label,omitempty" davinci:"label,config,omitempty"`
+	MultiValueSourceId   *string        `json:"multiValueSourceId,omitempty" davinci:"multiValueSourceId,config,omitempty"`
+	Name                 *string        `json:"name,omitempty" davinci:"name,config,omitempty"`
+	NodeType             *string        `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
+	Properties           *Properties    `json:"properties,omitempty" davinci:"properties,*,omitempty"`
+	Source               *string        `json:"source,omitempty" davinci:"source,config,omitempty"`
+	Status               *string        `json:"status,omitempty" davinci:"status,config,omitempty"`
+	Target               *string        `json:"target,omitempty" davinci:"target,config,omitempty"`
+	Type                 *string        `json:"type,omitempty" davinci:"type,config,omitempty"`
 }
 
 func (o EdgeData) MarshalJSON() ([]byte, error) {
@@ -28,9 +31,9 @@ func (o EdgeData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o EdgeData) ToMap() (map[string]interface{}, error) {
+func (o EdgeData) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.CapabilityName != nil {
 		result["capabilityName"] = o.CapabilityName
@@ -84,9 +87,7 @@ func (o EdgeData) ToMap() (map[string]interface{}, error) {
 		result["type"] = o.Type
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -98,7 +99,7 @@ func (o *EdgeData) UnmarshalJSON(bytes []byte) (err error) {
 		*o = EdgeData(varEdgeData)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "capabilityName")

--- a/davinci/models_elements.go
+++ b/davinci/models_elements.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Elements Elements
 type Elements struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Nodes                []Node                 `json:"nodes,omitempty" davinci:"nodes,*,omitempty"`
-	Edges                []Edge                 `json:"edges,omitempty" davinci:"edges,*,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Nodes                []Node         `json:"nodes,omitempty" davinci:"nodes,*,omitempty"`
+	Edges                []Edge         `json:"edges,omitempty" davinci:"edges,*,omitempty"`
 }
 
 func (o Elements) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o Elements) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Elements) ToMap() (map[string]interface{}, error) {
+func (o Elements) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Nodes != nil {
 		result["nodes"] = o.Nodes
@@ -33,9 +36,7 @@ func (o Elements) ToMap() (map[string]interface{}, error) {
 		result["edges"] = make([]Edge, 0)
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -47,7 +48,7 @@ func (o *Elements) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Elements(varElements)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "nodes")

--- a/davinci/models_flow.go
+++ b/davinci/models_flow.go
@@ -20,7 +20,7 @@ type FlowUpdateConfiguration struct {
 	GraphData    *GraphData    `json:"graphData,omitempty" davinci:"graphData,*,omitempty"`
 	InputSchema  []interface{} `json:"inputSchema,omitempty" davinci:"inputSchema,config,omitempty"`
 	OutputSchema *OutputSchema `json:"outputSchema,omitempty" davinci:"outputSchema,*,omitempty"`
-	Settings     interface{}   `json:"settings,omitempty" davinci:"settings,config,omitempty"`
+	Settings     *FlowSettings `json:"settings,omitempty" davinci:"settings,*,omitempty"`
 	Trigger      *Trigger      `json:"trigger,omitempty" davinci:"trigger,*,omitempty"`
 }
 

--- a/davinci/models_flow.go
+++ b/davinci/models_flow.go
@@ -1,10 +1,13 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Flow Flow
 type Flow struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
 	FlowConfiguration
 	FlowEnvironmentMetadata
 	FlowMetadata
@@ -69,7 +72,7 @@ func (o *Flow) UnmarshalDavinci(bytes []byte, opts ExportCmpOpts) (err error) {
 
 	*o = Flow(varFlow)
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err != nil {
 		return err
@@ -121,9 +124,9 @@ func (o Flow) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Flow) ToMap() (map[string]interface{}, error) {
+func (o Flow) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Description != nil {
 		result["authTokenExpireIds"] = o.AuthTokenExpireIds
@@ -232,9 +235,7 @@ func (o Flow) ToMap() (map[string]interface{}, error) {
 		result["versionInfo"] = o.VersionInfo
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -246,7 +247,7 @@ func (o *Flow) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Flow(varFlow)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "authTokenExpireIds")

--- a/davinci/models_flow_settings.go
+++ b/davinci/models_flow_settings.go
@@ -1,23 +1,26 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FlowSettings FlowSettings
 type FlowSettings struct {
-	AdditionalProperties          map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Csp                           *string                `json:"csp,omitempty" davinci:"csp,config,omitempty"`
-	Css                           *string                `json:"css,omitempty" davinci:"css,config,omitempty"`
-	CssLinks                      *[]string              `json:"cssLinks,omitempty" davinci:"cssLinks,config,omitempty"`
-	DebugMode                     *bool                  `json:"debugMode,omitempty" davinci:"debugMode,environmentmetadata,omitempty"`
-	FlowHttpTimeoutInSeconds      *int32                 `json:"flowHttpTimeoutInSeconds,omitempty" davinci:"flowHttpTimeoutInSeconds,config,omitempty"`
-	IntermediateLoadingScreenCSS  *string                `json:"intermediateLoadingScreenCSS,omitempty" davinci:"intermediateLoadingScreenCSS,config,omitempty"`
-	IntermediateLoadingScreenHTML *string                `json:"intermediateLoadingScreenHTML,omitempty" davinci:"intermediateLoadingScreenHTML,config,omitempty"`
-	LogLevel                      *int32                 `json:"logLevel,omitempty" davinci:"logLevel,environmentmetadata,omitempty"`
-	PingOneFlow                   *bool                  `json:"pingOneFlow,omitempty" davinci:"pingOneFlow,config,omitempty"`
-	ScrubSensitiveInfo            *bool                  `json:"scrubSensitiveInfo,omitempty" davinci:"scrubSensitiveInfo,config,omitempty"`
-	SensitiveInfoFields           *interface{}           `json:"sensitiveInfoFields,omitempty" davinci:"sensitiveInfoFields,config,omitempty"`
-	UseBetaAlgorithm              *bool                  `json:"useBetaAlgorithm,omitempty" davinci:"useBetaAlgorithm,config,omitempty"`
-	UseCustomCSS                  *bool                  `json:"useCustomCSS,omitempty" davinci:"useCustomCSS,config,omitempty"`
+	AdditionalProperties          map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Csp                           *string        `json:"csp,omitempty" davinci:"csp,config,omitempty"`
+	Css                           *string        `json:"css,omitempty" davinci:"css,config,omitempty"`
+	CssLinks                      *[]string      `json:"cssLinks,omitempty" davinci:"cssLinks,config,omitempty"`
+	DebugMode                     *bool          `json:"debugMode,omitempty" davinci:"debugMode,environmentmetadata,omitempty"`
+	FlowHttpTimeoutInSeconds      *int32         `json:"flowHttpTimeoutInSeconds,omitempty" davinci:"flowHttpTimeoutInSeconds,config,omitempty"`
+	IntermediateLoadingScreenCSS  *string        `json:"intermediateLoadingScreenCSS,omitempty" davinci:"intermediateLoadingScreenCSS,config,omitempty"`
+	IntermediateLoadingScreenHTML *string        `json:"intermediateLoadingScreenHTML,omitempty" davinci:"intermediateLoadingScreenHTML,config,omitempty"`
+	LogLevel                      *int32         `json:"logLevel,omitempty" davinci:"logLevel,environmentmetadata,omitempty"`
+	PingOneFlow                   *bool          `json:"pingOneFlow,omitempty" davinci:"pingOneFlow,config,omitempty"`
+	ScrubSensitiveInfo            *bool          `json:"scrubSensitiveInfo,omitempty" davinci:"scrubSensitiveInfo,config,omitempty"`
+	SensitiveInfoFields           *interface{}   `json:"sensitiveInfoFields,omitempty" davinci:"sensitiveInfoFields,config,omitempty"`
+	UseBetaAlgorithm              *bool          `json:"useBetaAlgorithm,omitempty" davinci:"useBetaAlgorithm,config,omitempty"`
+	UseCustomCSS                  *bool          `json:"useCustomCSS,omitempty" davinci:"useCustomCSS,config,omitempty"`
 }
 
 func (o FlowSettings) MarshalJSON() ([]byte, error) {
@@ -28,9 +31,9 @@ func (o FlowSettings) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FlowSettings) ToMap() (map[string]interface{}, error) {
+func (o FlowSettings) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Csp != nil {
 		result["csp"] = o.Csp
@@ -84,9 +87,7 @@ func (o FlowSettings) ToMap() (map[string]interface{}, error) {
 		result["useCustomCSS"] = o.UseCustomCSS
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -98,7 +99,7 @@ func (o *FlowSettings) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FlowSettings(varFlowSettings)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "csp")

--- a/davinci/models_flow_settings.go
+++ b/davinci/models_flow_settings.go
@@ -1,0 +1,121 @@
+package davinci
+
+import "encoding/json"
+
+type _FlowSettings FlowSettings
+type FlowSettings struct {
+	AdditionalProperties          map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Csp                           *string                `json:"csp,omitempty" davinci:"csp,config,omitempty"`
+	Css                           *string                `json:"css,omitempty" davinci:"css,config,omitempty"`
+	CssLinks                      *[]string              `json:"cssLinks,omitempty" davinci:"cssLinks,config,omitempty"`
+	DebugMode                     *bool                  `json:"debugMode,omitempty" davinci:"debugMode,environmentmetadata,omitempty"`
+	FlowHttpTimeoutInSeconds      *int32                 `json:"flowHttpTimeoutInSeconds,omitempty" davinci:"flowHttpTimeoutInSeconds,config,omitempty"`
+	IntermediateLoadingScreenCSS  *string                `json:"intermediateLoadingScreenCSS,omitempty" davinci:"intermediateLoadingScreenCSS,config,omitempty"`
+	IntermediateLoadingScreenHTML *string                `json:"intermediateLoadingScreenHTML,omitempty" davinci:"intermediateLoadingScreenHTML,config,omitempty"`
+	LogLevel                      *int32                 `json:"logLevel,omitempty" davinci:"logLevel,environmentmetadata,omitempty"`
+	PingOneFlow                   *bool                  `json:"pingOneFlow,omitempty" davinci:"pingOneFlow,config,omitempty"`
+	ScrubSensitiveInfo            *bool                  `json:"scrubSensitiveInfo,omitempty" davinci:"scrubSensitiveInfo,config,omitempty"`
+	SensitiveInfoFields           *interface{}           `json:"sensitiveInfoFields,omitempty" davinci:"sensitiveInfoFields,config,omitempty"`
+	UseBetaAlgorithm              *bool                  `json:"useBetaAlgorithm,omitempty" davinci:"useBetaAlgorithm,config,omitempty"`
+	UseCustomCSS                  *bool                  `json:"useCustomCSS,omitempty" davinci:"useCustomCSS,config,omitempty"`
+}
+
+func (o FlowSettings) MarshalJSON() ([]byte, error) {
+	result, err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(result)
+}
+
+func (o FlowSettings) ToMap() (map[string]interface{}, error) {
+
+	result := map[string]interface{}{}
+
+	if o.Csp != nil {
+		result["csp"] = o.Csp
+	}
+
+	if o.Css != nil {
+		result["css"] = o.Css
+	}
+
+	if o.CssLinks != nil {
+		result["cssLinks"] = o.CssLinks
+	}
+
+	if o.DebugMode != nil {
+		result["debugMode"] = o.DebugMode
+	}
+
+	if o.FlowHttpTimeoutInSeconds != nil {
+		result["flowHttpTimeoutInSeconds"] = o.FlowHttpTimeoutInSeconds
+	}
+
+	if o.IntermediateLoadingScreenCSS != nil {
+		result["intermediateLoadingScreenCSS"] = o.IntermediateLoadingScreenCSS
+	}
+
+	if o.IntermediateLoadingScreenHTML != nil {
+		result["intermediateLoadingScreenHTML"] = o.IntermediateLoadingScreenHTML
+	}
+
+	if o.LogLevel != nil {
+		result["logLevel"] = o.LogLevel
+	}
+
+	if o.PingOneFlow != nil {
+		result["pingOneFlow"] = o.PingOneFlow
+	}
+
+	if o.ScrubSensitiveInfo != nil {
+		result["scrubSensitiveInfo"] = o.ScrubSensitiveInfo
+	}
+
+	if o.SensitiveInfoFields != nil {
+		result["sensitiveInfoFields"] = o.SensitiveInfoFields
+	}
+
+	if o.UseBetaAlgorithm != nil {
+		result["useBetaAlgorithm"] = o.UseBetaAlgorithm
+	}
+
+	if o.UseCustomCSS != nil {
+		result["useCustomCSS"] = o.UseCustomCSS
+	}
+
+	for k, v := range o.AdditionalProperties {
+		result[k] = v
+	}
+
+	return result, nil
+}
+
+func (o *FlowSettings) UnmarshalJSON(bytes []byte) (err error) {
+	varFlowSettings := _FlowSettings{}
+
+	if err = json.Unmarshal(bytes, &varFlowSettings); err == nil {
+		*o = FlowSettings(varFlowSettings)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "csp")
+		delete(additionalProperties, "css")
+		delete(additionalProperties, "cssLinks")
+		delete(additionalProperties, "debugMode")
+		delete(additionalProperties, "flowHttpTimeoutInSeconds")
+		delete(additionalProperties, "intermediateLoadingScreenCSS")
+		delete(additionalProperties, "intermediateLoadingScreenHTML")
+		delete(additionalProperties, "logLevel")
+		delete(additionalProperties, "pingOneFlow")
+		delete(additionalProperties, "scrubSensitiveInfo")
+		delete(additionalProperties, "sensitiveInfoFields")
+		delete(additionalProperties, "useBetaAlgorithm")
+		delete(additionalProperties, "useCustomCSS")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+}

--- a/davinci/models_flow_variable.go
+++ b/davinci/models_flow_variable.go
@@ -1,24 +1,27 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FlowVariable FlowVariable
 type FlowVariable struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	ID                   *string                `json:"id,omitempty" davinci:"id,environmentmetadata,omitempty"`
-	CompanyID            *string                `json:"companyId,omitempty" davinci:"companyId,environmentmetadata,omitempty"`
-	Context              *string                `json:"context,omitempty" davinci:"context,config,omitempty"`
-	CreatedDate          *EpochTime             `json:"createdDate,omitempty" davinci:"createdDate,flowvariables,omitempty"`
-	CustomerID           *string                `json:"customerId,omitempty" davinci:"customerId,environmentmetadata,omitempty"`
-	Fields               *FlowVariableFields    `json:"fields,omitempty" davinci:"fields,*,omitempty"`
-	FlowID               *string                `json:"flowId,omitempty" davinci:"flowId,environmentmetadata,omitempty"`
-	Key                  *float64               `json:"key,omitempty" davinci:"key,flowmetadata,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,flowvariables,omitempty"`
-	Name                 string                 `json:"name" davinci:"name,config"`
-	Type                 string                 `json:"type" davinci:"type,config"`
-	UpdatedDate          *EpochTime             `json:"updatedDate,omitempty" davinci:"updatedDate,flowvariables,omitempty"`
-	Value                interface{}            `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
-	Visibility           *string                `json:"visibility,omitempty" davinci:"visibility,flowvariables,omitempty"`
+	AdditionalProperties map[string]any      `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	ID                   *string             `json:"id,omitempty" davinci:"id,environmentmetadata,omitempty"`
+	CompanyID            *string             `json:"companyId,omitempty" davinci:"companyId,environmentmetadata,omitempty"`
+	Context              *string             `json:"context,omitempty" davinci:"context,config,omitempty"`
+	CreatedDate          *EpochTime          `json:"createdDate,omitempty" davinci:"createdDate,flowvariables,omitempty"`
+	CustomerID           *string             `json:"customerId,omitempty" davinci:"customerId,environmentmetadata,omitempty"`
+	Fields               *FlowVariableFields `json:"fields,omitempty" davinci:"fields,*,omitempty"`
+	FlowID               *string             `json:"flowId,omitempty" davinci:"flowId,environmentmetadata,omitempty"`
+	Key                  *float64            `json:"key,omitempty" davinci:"key,flowmetadata,omitempty"`
+	Label                *string             `json:"label,omitempty" davinci:"label,flowvariables,omitempty"`
+	Name                 string              `json:"name" davinci:"name,config"`
+	Type                 string              `json:"type" davinci:"type,config"`
+	UpdatedDate          *EpochTime          `json:"updatedDate,omitempty" davinci:"updatedDate,flowvariables,omitempty"`
+	Value                interface{}         `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
+	Visibility           *string             `json:"visibility,omitempty" davinci:"visibility,flowvariables,omitempty"`
 }
 
 func (o FlowVariable) MarshalJSON() ([]byte, error) {
@@ -29,9 +32,9 @@ func (o FlowVariable) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FlowVariable) ToMap() (map[string]interface{}, error) {
+func (o FlowVariable) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	result["id"] = o.ID
 	result["companyId"] = o.CompanyID
@@ -52,9 +55,7 @@ func (o FlowVariable) ToMap() (map[string]interface{}, error) {
 	result["value"] = o.Value
 	result["visibility"] = o.Visibility
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -66,7 +67,7 @@ func (o *FlowVariable) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FlowVariable(varFlowVariable)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")

--- a/davinci/models_flow_variable_fields.go
+++ b/davinci/models_flow_variable_fields.go
@@ -1,16 +1,19 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FlowVariableFields FlowVariableFields
 type FlowVariableFields struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
-	DisplayName          *string                `json:"displayName,omitempty" davinci:"displayName,flowvariables,omitempty"`
-	Mutable              *bool                  `json:"mutable,omitempty" davinci:"mutable,flowvariables,omitempty"`
-	Value                interface{}            `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
-	Min                  *int32                 `json:"min,omitempty" davinci:"min,flowvariables,omitempty"`
-	Max                  *int32                 `json:"max,omitempty" davinci:"max,flowvariables,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Type                 *string        `json:"type,omitempty" davinci:"type,config,omitempty"`
+	DisplayName          *string        `json:"displayName,omitempty" davinci:"displayName,flowvariables,omitempty"`
+	Mutable              *bool          `json:"mutable,omitempty" davinci:"mutable,flowvariables,omitempty"`
+	Value                interface{}    `json:"value,omitempty" davinci:"value,flowvariables,omitempty"`
+	Min                  *int32         `json:"min,omitempty" davinci:"min,flowvariables,omitempty"`
+	Max                  *int32         `json:"max,omitempty" davinci:"max,flowvariables,omitempty"`
 }
 
 func (o FlowVariableFields) MarshalJSON() ([]byte, error) {
@@ -21,9 +24,9 @@ func (o FlowVariableFields) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FlowVariableFields) ToMap() (map[string]interface{}, error) {
+func (o FlowVariableFields) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Type != nil {
 		result["type"] = o.Type
@@ -49,9 +52,7 @@ func (o FlowVariableFields) ToMap() (map[string]interface{}, error) {
 		result["max"] = o.Max
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -63,7 +64,7 @@ func (o *FlowVariableFields) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FlowVariableFields(varFlowVariableFields)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "type")

--- a/davinci/models_flows.go
+++ b/davinci/models_flows.go
@@ -36,4 +36,4 @@ type FlowUpdate struct {
 //		Value *bool `json:"value,omitempty"`
 //	}
 
-type AdditionalProperties map[string]interface{}
+type AdditionalProperties map[string]any

--- a/davinci/models_formdata.go
+++ b/davinci/models_formdata.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FormData FormData
 type FormData struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Value                []FormDataValue        `json:"value,omitempty" davinci:"value,config,omitempty"`
+	AdditionalProperties map[string]any  `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Value                []FormDataValue `json:"value,omitempty" davinci:"value,config,omitempty"`
 }
 
 func (o FormData) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o FormData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FormData) ToMap() (map[string]interface{}, error) {
+func (o FormData) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Value != nil {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *FormData) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FormData(varFormData)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "value")

--- a/davinci/models_formdata_value.go
+++ b/davinci/models_formdata_value.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FormDataValue FormDataValue
 type FormDataValue struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Key                  *string                `json:"key,omitempty" davinci:"key,config,omitempty"`
-	Value                *string                `json:"value,omitempty" davinci:"value,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Key                  *string        `json:"key,omitempty" davinci:"key,config,omitempty"`
+	Value                *string        `json:"value,omitempty" davinci:"value,config,omitempty"`
 }
 
 func (o FormDataValue) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o FormDataValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FormDataValue) ToMap() (map[string]interface{}, error) {
+func (o FormDataValue) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Key != nil {
 		result["key"] = o.Key
@@ -29,9 +32,7 @@ func (o FormDataValue) ToMap() (map[string]interface{}, error) {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -43,7 +44,7 @@ func (o *FormDataValue) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FormDataValue(varFormDataValue)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "key")

--- a/davinci/models_formobj.go
+++ b/davinci/models_formobj.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _FormObj FormObj
 type FormObj struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Value                *string                `json:"value,omitempty" davinci:"value,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Value                *string        `json:"value,omitempty" davinci:"value,config,omitempty"`
 }
 
 func (o FormObj) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o FormObj) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o FormObj) ToMap() (map[string]interface{}, error) {
+func (o FormObj) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Value != nil {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *FormObj) UnmarshalJSON(bytes []byte) (err error) {
 		*o = FormObj(varFormObj)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "value")

--- a/davinci/models_graph_data.go
+++ b/davinci/models_graph_data.go
@@ -1,22 +1,25 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _GraphData GraphData
 type GraphData struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	BoxSelectionEnabled  *bool                  `json:"boxSelectionEnabled,omitempty" davinci:"boxSelectionEnabled,designercue,omitempty"`
-	Data                 *Data                  `json:"data,omitempty" davinci:"data,*,omitempty"`
-	Elements             *Elements              `json:"elements,omitempty" davinci:"elements,*,omitempty"`
-	MaxZoom              *float64               `json:"maxZoom,omitempty" davinci:"maxZoom,designercue,omitempty"`
-	MinZoom              *float64               `json:"minZoom,omitempty" davinci:"minZoom,designercue,omitempty"`
-	Pan                  *Pan                   `json:"pan,omitempty" davinci:"pan,*,omitempty"`
-	PanningEnabled       *bool                  `json:"panningEnabled,omitempty" davinci:"panningEnabled,designercue,omitempty"`
-	Renderer             *Renderer              `json:"renderer,omitempty" davinci:"renderer,*,omitempty"`
-	UserPanningEnabled   *bool                  `json:"userPanningEnabled,omitempty" davinci:"userPanningEnabled,designercue,omitempty"`
-	UserZoomingEnabled   *bool                  `json:"userZoomingEnabled,omitempty" davinci:"userZoomingEnabled,designercue,omitempty"`
-	Zoom                 *int32                 `json:"zoom,omitempty" davinci:"zoom,designercue,omitempty"`
-	ZoomingEnabled       *bool                  `json:"zoomingEnabled,omitempty" davinci:"zoomingEnabled,designercue,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	BoxSelectionEnabled  *bool          `json:"boxSelectionEnabled,omitempty" davinci:"boxSelectionEnabled,designercue,omitempty"`
+	Data                 *Data          `json:"data,omitempty" davinci:"data,*,omitempty"`
+	Elements             *Elements      `json:"elements,omitempty" davinci:"elements,*,omitempty"`
+	MaxZoom              *float64       `json:"maxZoom,omitempty" davinci:"maxZoom,designercue,omitempty"`
+	MinZoom              *float64       `json:"minZoom,omitempty" davinci:"minZoom,designercue,omitempty"`
+	Pan                  *Pan           `json:"pan,omitempty" davinci:"pan,*,omitempty"`
+	PanningEnabled       *bool          `json:"panningEnabled,omitempty" davinci:"panningEnabled,designercue,omitempty"`
+	Renderer             *Renderer      `json:"renderer,omitempty" davinci:"renderer,*,omitempty"`
+	UserPanningEnabled   *bool          `json:"userPanningEnabled,omitempty" davinci:"userPanningEnabled,designercue,omitempty"`
+	UserZoomingEnabled   *bool          `json:"userZoomingEnabled,omitempty" davinci:"userZoomingEnabled,designercue,omitempty"`
+	Zoom                 *int32         `json:"zoom,omitempty" davinci:"zoom,designercue,omitempty"`
+	ZoomingEnabled       *bool          `json:"zoomingEnabled,omitempty" davinci:"zoomingEnabled,designercue,omitempty"`
 }
 
 func (o GraphData) MarshalJSON() ([]byte, error) {
@@ -27,9 +30,9 @@ func (o GraphData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o GraphData) ToMap() (map[string]interface{}, error) {
+func (o GraphData) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.BoxSelectionEnabled != nil {
 		result["boxSelectionEnabled"] = o.BoxSelectionEnabled
@@ -79,9 +82,7 @@ func (o GraphData) ToMap() (map[string]interface{}, error) {
 		result["zoomingEnabled"] = o.ZoomingEnabled
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -93,7 +94,7 @@ func (o *GraphData) UnmarshalJSON(bytes []byte) (err error) {
 		*o = GraphData(varGraphData)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "boxSelectionEnabled")

--- a/davinci/models_label_value.go
+++ b/davinci/models_label_value.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _LabelValue LabelValue
 type LabelValue struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
-	Value                *string                `json:"value,omitempty" davinci:"value,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Label                *string        `json:"label,omitempty" davinci:"label,config,omitempty"`
+	Value                *string        `json:"value,omitempty" davinci:"value,config,omitempty"`
 }
 
 func (o LabelValue) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o LabelValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o LabelValue) ToMap() (map[string]interface{}, error) {
+func (o LabelValue) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Label != nil {
 		result["label"] = o.Label
@@ -29,9 +32,7 @@ func (o LabelValue) ToMap() (map[string]interface{}, error) {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -43,7 +44,7 @@ func (o *LabelValue) UnmarshalJSON(bytes []byte) (err error) {
 		*o = LabelValue(varLabelValue)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "label")

--- a/davinci/models_node.go
+++ b/davinci/models_node.go
@@ -1,20 +1,23 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Node Node
 type Node struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Data                 *NodeData              `json:"data,omitempty" davinci:"data,*,omitempty"`
-	Position             *Position              `json:"position,omitempty" davinci:"position,*,omitempty"`
-	Group                string                 `json:"group" davinci:"group,designercue"`
-	Removed              bool                   `json:"removed" davinci:"removed,designercue"`
-	Selected             bool                   `json:"selected" davinci:"selected,designercue"`
-	Selectable           bool                   `json:"selectable" davinci:"selectable,designercue"`
-	Locked               bool                   `json:"locked" davinci:"locked,designercue"`
-	Grabbable            bool                   `json:"grabbable" davinci:"grabbable,designercue"`
-	Pannable             bool                   `json:"pannable" davinci:"pannable,designercue"`
-	Classes              string                 `json:"classes" davinci:"classes,config"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Data                 *NodeData      `json:"data,omitempty" davinci:"data,*,omitempty"`
+	Position             *Position      `json:"position,omitempty" davinci:"position,*,omitempty"`
+	Group                string         `json:"group" davinci:"group,designercue"`
+	Removed              bool           `json:"removed" davinci:"removed,designercue"`
+	Selected             bool           `json:"selected" davinci:"selected,designercue"`
+	Selectable           bool           `json:"selectable" davinci:"selectable,designercue"`
+	Locked               bool           `json:"locked" davinci:"locked,designercue"`
+	Grabbable            bool           `json:"grabbable" davinci:"grabbable,designercue"`
+	Pannable             bool           `json:"pannable" davinci:"pannable,designercue"`
+	Classes              string         `json:"classes" davinci:"classes,config"`
 }
 
 func (o Node) MarshalJSON() ([]byte, error) {
@@ -25,9 +28,9 @@ func (o Node) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Node) ToMap() (map[string]interface{}, error) {
+func (o Node) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Data != nil {
 		result["data"] = o.Data
@@ -46,9 +49,7 @@ func (o Node) ToMap() (map[string]interface{}, error) {
 	result["pannable"] = o.Pannable
 	result["classes"] = o.Classes
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -60,7 +61,7 @@ func (o *Node) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Node(varNode)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "data")

--- a/davinci/models_node_data.go
+++ b/davinci/models_node_data.go
@@ -1,22 +1,25 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _NodeData NodeData
 type NodeData struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	CapabilityName       *string                `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
-	ConnectionID         *string                `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
-	ConnectorID          *string                `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
-	ID                   *string                `json:"id,omitempty" davinci:"id,config,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
-	Name                 *string                `json:"name,omitempty" davinci:"name,config,omitempty"`
-	NodeType             *string                `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
-	Properties           *Properties            `json:"properties" davinci:"properties,*"`
-	Source               *string                `json:"source,omitempty" davinci:"source,config,omitempty"`
-	Status               *string                `json:"status,omitempty" davinci:"status,config,omitempty"`
-	Target               *string                `json:"target,omitempty" davinci:"target,config,omitempty"`
-	Type                 *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	CapabilityName       *string        `json:"capabilityName,omitempty" davinci:"capabilityName,config,omitempty"`
+	ConnectionID         *string        `json:"connectionId,omitempty" davinci:"connectionId,config,omitempty"`
+	ConnectorID          *string        `json:"connectorId,omitempty" davinci:"connectorId,config,omitempty"`
+	ID                   *string        `json:"id,omitempty" davinci:"id,config,omitempty"`
+	Label                *string        `json:"label,omitempty" davinci:"label,config,omitempty"`
+	Name                 *string        `json:"name,omitempty" davinci:"name,config,omitempty"`
+	NodeType             *string        `json:"nodeType,omitempty" davinci:"nodeType,config,omitempty"`
+	Properties           *Properties    `json:"properties" davinci:"properties,*"`
+	Source               *string        `json:"source,omitempty" davinci:"source,config,omitempty"`
+	Status               *string        `json:"status,omitempty" davinci:"status,config,omitempty"`
+	Target               *string        `json:"target,omitempty" davinci:"target,config,omitempty"`
+	Type                 *string        `json:"type,omitempty" davinci:"type,config,omitempty"`
 }
 
 func (o NodeData) MarshalJSON() ([]byte, error) {
@@ -27,9 +30,9 @@ func (o NodeData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o NodeData) ToMap() (map[string]interface{}, error) {
+func (o NodeData) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.CapabilityName != nil {
 		result["capabilityName"] = o.CapabilityName
@@ -79,9 +82,7 @@ func (o NodeData) ToMap() (map[string]interface{}, error) {
 		result["type"] = o.Type
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -93,7 +94,7 @@ func (o *NodeData) UnmarshalJSON(bytes []byte) (err error) {
 		*o = NodeData(varNodeData)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "capabilityName")

--- a/davinci/models_output_schema.go
+++ b/davinci/models_output_schema.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _OutputSchema OutputSchema
 type OutputSchema struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Output               interface{}            `json:"output,omitempty" davinci:"output,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Output               interface{}    `json:"output,omitempty" davinci:"output,config,omitempty"`
 }
 
 func (o OutputSchema) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o OutputSchema) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o OutputSchema) ToMap() (map[string]interface{}, error) {
+func (o OutputSchema) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Output != nil {
 		result["output"] = o.Output
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *OutputSchema) UnmarshalJSON(bytes []byte) (err error) {
 		*o = OutputSchema(varOutputSchema)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "output")

--- a/davinci/models_pan.go
+++ b/davinci/models_pan.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Pan Pan
 type Pan struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	X                    *float64               `json:"x,omitempty" davinci:"x,designercue,omitempty"`
-	Y                    *float64               `json:"y,omitempty" davinci:"y,designercue,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	X                    *float64       `json:"x,omitempty" davinci:"x,designercue,omitempty"`
+	Y                    *float64       `json:"y,omitempty" davinci:"y,designercue,omitempty"`
 }
 
 func (o Pan) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o Pan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Pan) ToMap() (map[string]interface{}, error) {
+func (o Pan) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.X != nil {
 		result["x"] = o.X
@@ -29,9 +32,7 @@ func (o Pan) ToMap() (map[string]interface{}, error) {
 		result["y"] = o.Y
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -43,7 +44,7 @@ func (o *Pan) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Pan(varPan)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "x")

--- a/davinci/models_position.go
+++ b/davinci/models_position.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Position Position
 type Position struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	X                    *float64               `json:"x,omitempty" davinci:"x,designercue,omitempty"`
-	Y                    *float64               `json:"y,omitempty" davinci:"y,designercue,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	X                    *float64       `json:"x,omitempty" davinci:"x,designercue,omitempty"`
+	Y                    *float64       `json:"y,omitempty" davinci:"y,designercue,omitempty"`
 }
 
 func (o Position) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o Position) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Position) ToMap() (map[string]interface{}, error) {
+func (o Position) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.X != nil {
 		result["x"] = o.X
@@ -29,9 +32,7 @@ func (o Position) ToMap() (map[string]interface{}, error) {
 		result["y"] = o.Y
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -43,7 +44,7 @@ func (o *Position) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Position(varPosition)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "x")

--- a/davinci/models_properties.go
+++ b/davinci/models_properties.go
@@ -1,16 +1,19 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Properties Properties
 type Properties struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Form                 *Form                  `json:"form,omitempty" davinci:"form,config,omitempty"`
-	FormData             *FormData              `json:"formData,omitempty" davinci:"formData,config,omitempty"`
-	SubFlowID            *SubFlowID             `json:"subFlowId,omitempty" davinci:"subFlowId,config,omitempty"`
-	SubFlowVersionID     *SubFlowVersionID      `json:"subFlowVersionId,omitempty" davinci:"subFlowVersionId,config,omitempty"`
-	SaveFlowVariables    *SaveFlowVariables     `json:"saveFlowVariables,omitempty" davinci:"saveFlowVariables,*,omitempty"`
-	SaveVariables        *SaveFlowVariables     `json:"saveVariables,omitempty" davinci:"saveVariables,*,omitempty"`
+	AdditionalProperties map[string]any     `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Form                 *Form              `json:"form,omitempty" davinci:"form,config,omitempty"`
+	FormData             *FormData          `json:"formData,omitempty" davinci:"formData,config,omitempty"`
+	SubFlowID            *SubFlowID         `json:"subFlowId,omitempty" davinci:"subFlowId,config,omitempty"`
+	SubFlowVersionID     *SubFlowVersionID  `json:"subFlowVersionId,omitempty" davinci:"subFlowVersionId,config,omitempty"`
+	SaveFlowVariables    *SaveFlowVariables `json:"saveFlowVariables,omitempty" davinci:"saveFlowVariables,*,omitempty"`
+	SaveVariables        *SaveFlowVariables `json:"saveVariables,omitempty" davinci:"saveVariables,*,omitempty"`
 }
 
 func (o Properties) MarshalJSON() ([]byte, error) {
@@ -21,9 +24,9 @@ func (o Properties) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Properties) ToMap() (map[string]interface{}, error) {
+func (o Properties) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Form != nil {
 		result["form"] = o.Form
@@ -49,9 +52,7 @@ func (o Properties) ToMap() (map[string]interface{}, error) {
 		result["saveVariables"] = o.SaveVariables
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -63,7 +64,7 @@ func (o *Properties) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Properties(varProperties)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "form")

--- a/davinci/models_renderer.go
+++ b/davinci/models_renderer.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Renderer Renderer
 type Renderer struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Name                 *string                `json:"name,omitempty" davinci:"name,designercue,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Name                 *string        `json:"name,omitempty" davinci:"name,designercue,omitempty"`
 }
 
 func (o Renderer) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o Renderer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Renderer) ToMap() (map[string]interface{}, error) {
+func (o Renderer) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Name != nil {
 		result["name"] = o.Name
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *Renderer) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Renderer(varRenderer)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")

--- a/davinci/models_save_flow_variable.go
+++ b/davinci/models_save_flow_variable.go
@@ -1,16 +1,19 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _SaveFlowVariable SaveFlowVariable
 type SaveFlowVariable struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Key                  *float64               `json:"key,omitempty" davinci:"key,config,omitempty"`
-	Label                *string                `json:"label,omitempty" davinci:"label,config,omitempty"`
-	Name                 string                 `json:"name" davinci:"name,config"`
-	Type                 string                 `json:"type" davinci:"type,config"`
-	Value                interface{}            `json:"value,omitempty" davinci:"value,config,omitempty"`
-	NameDefault          *string                `json:"nameDefault,omitempty" davinci:"nameDefault,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Key                  *float64       `json:"key,omitempty" davinci:"key,config,omitempty"`
+	Label                *string        `json:"label,omitempty" davinci:"label,config,omitempty"`
+	Name                 string         `json:"name" davinci:"name,config"`
+	Type                 string         `json:"type" davinci:"type,config"`
+	Value                interface{}    `json:"value,omitempty" davinci:"value,config,omitempty"`
+	NameDefault          *string        `json:"nameDefault,omitempty" davinci:"nameDefault,config,omitempty"`
 }
 
 func (o SaveFlowVariable) MarshalJSON() ([]byte, error) {
@@ -21,9 +24,9 @@ func (o SaveFlowVariable) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o SaveFlowVariable) ToMap() (map[string]interface{}, error) {
+func (o SaveFlowVariable) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	result["key"] = o.Key
 	result["label"] = o.Label
@@ -31,10 +34,8 @@ func (o SaveFlowVariable) ToMap() (map[string]interface{}, error) {
 	result["type"] = o.Type
 	result["value"] = o.Value
 	result["nameDefault"] = o.NameDefault
-	
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -46,7 +47,7 @@ func (o *SaveFlowVariable) UnmarshalJSON(bytes []byte) (err error) {
 		*o = SaveFlowVariable(varSaveFlowVariable)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "key")

--- a/davinci/models_save_flow_variables.go
+++ b/davinci/models_save_flow_variables.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _SaveFlowVariables SaveFlowVariables
 type SaveFlowVariables struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Value                []SaveFlowVariable     `json:"value,omitempty" davinci:"value,*,omitempty"`
+	AdditionalProperties map[string]any     `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Value                []SaveFlowVariable `json:"value,omitempty" davinci:"value,*,omitempty"`
 }
 
 func (o SaveFlowVariables) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o SaveFlowVariables) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o SaveFlowVariables) ToMap() (map[string]interface{}, error) {
+func (o SaveFlowVariables) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Value != nil {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *SaveFlowVariables) UnmarshalJSON(bytes []byte) (err error) {
 		*o = SaveFlowVariables(varSaveFlowVariables)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "value")

--- a/davinci/models_sub_flow_id.go
+++ b/davinci/models_sub_flow_id.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _SubFlowID SubFlowID
 type SubFlowID struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Value                *SubFlowValue          `json:"value,omitempty" davinci:"value,*,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Value                *SubFlowValue  `json:"value,omitempty" davinci:"value,*,omitempty"`
 }
 
 func (o SubFlowID) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o SubFlowID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o SubFlowID) ToMap() (map[string]interface{}, error) {
+func (o SubFlowID) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Value != nil {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *SubFlowID) UnmarshalJSON(bytes []byte) (err error) {
 		*o = SubFlowID(varSubFlowID)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "value")

--- a/davinci/models_sub_flow_properties.go
+++ b/davinci/models_sub_flow_properties.go
@@ -1,12 +1,15 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _SubFlowProperties SubFlowProperties
 type SubFlowProperties struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	SubFlowID            *SubFlowID             `json:"subFlowId,omitempty" davinci:"subFlowId,*,omitempty"`
-	SubFlowProperties    *SubFlowProperties     `json:"subFlowVersionId,omitempty" davinci:"subFlowVersionId,*,omitempty"`
+	AdditionalProperties map[string]any     `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	SubFlowID            *SubFlowID         `json:"subFlowId,omitempty" davinci:"subFlowId,*,omitempty"`
+	SubFlowProperties    *SubFlowProperties `json:"subFlowVersionId,omitempty" davinci:"subFlowVersionId,*,omitempty"`
 }
 
 func (o SubFlowProperties) MarshalJSON() ([]byte, error) {
@@ -17,9 +20,9 @@ func (o SubFlowProperties) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o SubFlowProperties) ToMap() (map[string]interface{}, error) {
+func (o SubFlowProperties) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.SubFlowID != nil {
 		result["subFlowId"] = o.SubFlowID
@@ -29,9 +32,7 @@ func (o SubFlowProperties) ToMap() (map[string]interface{}, error) {
 		result["subFlowVersionId"] = o.SubFlowProperties
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -43,7 +44,7 @@ func (o *SubFlowProperties) UnmarshalJSON(bytes []byte) (err error) {
 		*o = SubFlowProperties(varSubFlowProperties)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "subFlowId")

--- a/davinci/models_sub_flow_version_id.go
+++ b/davinci/models_sub_flow_version_id.go
@@ -1,10 +1,13 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _SubFlowVersionID SubFlowVersionID
 type SubFlowVersionID struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	AdditionalProperties map[string]any         `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
 	Value                *SubFlowVersionIDValue `json:"value,omitempty" davinci:"value,*,omitempty"`
 }
 
@@ -16,17 +19,15 @@ func (o SubFlowVersionID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o SubFlowVersionID) ToMap() (map[string]interface{}, error) {
+func (o SubFlowVersionID) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.Value != nil {
 		result["value"] = o.Value
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *SubFlowVersionID) UnmarshalJSON(bytes []byte) (err error) {
 		*o = SubFlowVersionID(varSubFlowVersionID)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "value")

--- a/davinci/models_trigger.go
+++ b/davinci/models_trigger.go
@@ -1,11 +1,14 @@
 package davinci
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 type _Trigger Trigger
 type Trigger struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	TriggerType          *string                `json:"type,omitempty" davinci:"type,config,omitempty"`
+	AdditionalProperties map[string]any `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	TriggerType          *string        `json:"type,omitempty" davinci:"type,config,omitempty"`
 }
 
 func (o Trigger) MarshalJSON() ([]byte, error) {
@@ -16,17 +19,15 @@ func (o Trigger) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (o Trigger) ToMap() (map[string]interface{}, error) {
+func (o Trigger) ToMap() (map[string]any, error) {
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	if o.TriggerType != nil {
 		result["type"] = o.TriggerType
 	}
 
-	for k, v := range o.AdditionalProperties {
-		result[k] = v
-	}
+	maps.Copy(result, o.AdditionalProperties)
 
 	return result, nil
 }
@@ -38,7 +39,7 @@ func (o *Trigger) UnmarshalJSON(bytes []byte) (err error) {
 		*o = Trigger(varTrigger)
 	}
 
-	additionalProperties := make(map[string]interface{})
+	additionalProperties := make(map[string]any)
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "type")

--- a/davinci/test/decode_test_model.go
+++ b/davinci/test/decode_test_model.go
@@ -3,32 +3,32 @@ package test
 import "github.com/samir-gandhi/davinci-client-go/davinci"
 
 type TestModel struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Test1                *string                `davinci:"test1Field,environmentmetadata,omitempty"`
-	Test2                *string                `davinci:"test2Field,config,omitempty"`
-	Test3                *davinci.EpochTime     `davinci:"test3Field,versionmetadata,omitempty"`
-	Test4                *string                `davinci:"test4Field,environmentmetadata,omitempty"`
-	Test5                *TestModel2            `davinci:"test5Field,*,omitempty"`
-	Test6                *string                `davinci:"test6Field,environmentmetadata,omitempty"`
-	Test7                *float64               `davinci:"test7Field,flowmetadata,omitempty"`
-	Test8                *string                `davinci:"test8Field,config,omitempty"`
-	Test9                *string                `davinci:"test9Field,designercue,omitempty"`
-	Test10               *string                `davinci:"test10Field,config,omitempty"`
-	Test11               *string                `davinci:"test11Field,designercue,omitempty"`
-	Test12               *string                `davinci:"test12Field,versionmetadata,omitempty"`
+	AdditionalProperties map[string]any     `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Test1                *string            `davinci:"test1Field,environmentmetadata,omitempty"`
+	Test2                *string            `davinci:"test2Field,config,omitempty"`
+	Test3                *davinci.EpochTime `davinci:"test3Field,versionmetadata,omitempty"`
+	Test4                *string            `davinci:"test4Field,environmentmetadata,omitempty"`
+	Test5                *TestModel2        `davinci:"test5Field,*,omitempty"`
+	Test6                *string            `davinci:"test6Field,environmentmetadata,omitempty"`
+	Test7                *float64           `davinci:"test7Field,flowmetadata,omitempty"`
+	Test8                *string            `davinci:"test8Field,config,omitempty"`
+	Test9                *string            `davinci:"test9Field,designercue,omitempty"`
+	Test10               *string            `davinci:"test10Field,config,omitempty"`
+	Test11               *string            `davinci:"test11Field,designercue,omitempty"`
+	Test12               *string            `davinci:"test12Field,versionmetadata,omitempty"`
 }
 
 type TestModel2 struct {
-	AdditionalProperties map[string]interface{} `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Test1                *string                `davinci:"test1Field,environmentmetadata,omitempty"`
-	Test2                *string                `davinci:"test2Field,config,omitempty"`
-	Test3                *davinci.EpochTime     `davinci:"test3Field,versionmetadata,omitempty"`
-	Test4                *string                `davinci:"test4Field,environmentmetadata,omitempty"`
-	Test6                *string                `davinci:"test6Field,-,omitempty"`
-	Test7                *float64               `davinci:"test7Field,flowmetadata,omitempty"`
-	Test8                *string                `davinci:"test8Field,config,omitempty"`
-	Test9                *string                `davinci:"test9Field,designercue,omitempty"`
-	Test10               *string                `davinci:"test10Field,config,omitempty"`
-	Test11               *string                `davinci:"test11Field,designercue,omitempty"`
-	Test12               *string                `davinci:"test12Field,versionmetadata,omitempty"`
+	AdditionalProperties map[string]any     `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Test1                *string            `davinci:"test1Field,environmentmetadata,omitempty"`
+	Test2                *string            `davinci:"test2Field,config,omitempty"`
+	Test3                *davinci.EpochTime `davinci:"test3Field,versionmetadata,omitempty"`
+	Test4                *string            `davinci:"test4Field,environmentmetadata,omitempty"`
+	Test6                *string            `davinci:"test6Field,-,omitempty"`
+	Test7                *float64           `davinci:"test7Field,flowmetadata,omitempty"`
+	Test8                *string            `davinci:"test8Field,config,omitempty"`
+	Test9                *string            `davinci:"test9Field,designercue,omitempty"`
+	Test10               *string            `davinci:"test10Field,config,omitempty"`
+	Test11               *string            `davinci:"test11Field,designercue,omitempty"`
+	Test12               *string            `davinci:"test12Field,versionmetadata,omitempty"`
 }

--- a/davinci/test/test_data.go
+++ b/davinci/test/test_data.go
@@ -5,30 +5,30 @@ import "github.com/samir-gandhi/davinci-client-go/davinci"
 func Data_FullBasic() davinci.Flow {
 
 	return davinci.Flow{
-		AdditionalProperties: map[string]interface{}{
+		AdditionalProperties: map[string]any{
 			"custom-attribute-1": "custom-attribute-1-value",
 			"custom-attribute-2": "custom-attribute-2-value",
 		},
 		FlowConfiguration: davinci.FlowConfiguration{
 			FlowUpdateConfiguration: davinci.FlowUpdateConfiguration{
 				GraphData: &davinci.GraphData{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-attribute-1-value",
 						"custom-attribute-2": "custom-attribute-2-value",
 					},
 					Elements: &davinci.Elements{
-						AdditionalProperties: map[string]interface{}{
+						AdditionalProperties: map[string]any{
 							"custom-attribute-1": "custom-attribute-1-value",
 							"custom-attribute-2": "custom-attribute-2-value",
 						},
 						Nodes: []davinci.Node{
 							{
-								AdditionalProperties: map[string]interface{}{
+								AdditionalProperties: map[string]any{
 									"custom-attribute-1": "custom-attribute-1-value",
 									"custom-attribute-2": "custom-attribute-2-value",
 								},
 								Data: &davinci.NodeData{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"custom-attribute-1": "custom-attribute-1-value",
 										"custom-attribute-2": "custom-attribute-2-value",
 									},
@@ -70,10 +70,10 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											AdditionalProperties: map[string]interface{}{
+											AdditionalProperties: map[string]any{
 												"custom-attribute-1": "custom-attribute-1-value",
 												"custom-attribute-2": "custom-attribute-2-value",
-												"message": map[string]interface{}{
+												"message": map[string]any{
 													"custom-attribute-1": "custom-attribute-1-value",
 													"custom-attribute-2": "custom-attribute-2-value",
 													"value":              "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Hello, world?\"\n      }\n    ]\n  }\n]",
@@ -83,7 +83,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"custom-attribute-1": "custom-attribute-1-value",
 										"custom-attribute-2": "custom-attribute-2-value",
 									},
@@ -106,9 +106,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "8fvg7tfr8j"
 										return &v
@@ -123,7 +123,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(426.5)
 										return &v
@@ -143,9 +143,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "nx0o1b2cmw"
 										return &v
@@ -184,11 +184,11 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											AdditionalProperties: map[string]interface{}{
-												"leftValueA": map[string]interface{}{
+											AdditionalProperties: map[string]any{
+												"leftValueA": map[string]any{
 													"value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"1\"\n      }\n    ]\n  }\n]",
 												},
-												"rightValueB": map[string]interface{}{
+												"rightValueB": map[string]any{
 													"value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"1\"\n      }\n    ]\n  }\n]",
 												},
 											},
@@ -196,7 +196,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(576)
 										return &v
@@ -216,9 +216,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "cdcw8k7dnx"
 										return &v
@@ -233,11 +233,11 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											AdditionalProperties: map[string]interface{}{
-												"vsp1ewtr9m": map[string]interface{}{
+											AdditionalProperties: map[string]any{
+												"vsp1ewtr9m": map[string]any{
 													"value": "allTriggersFalse",
 												},
-												"xb74p6rkd8": map[string]interface{}{
+												"xb74p6rkd8": map[string]any{
 													"value": "anyTriggersFalse",
 												},
 											},
@@ -245,7 +245,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(717)
 										return &v
@@ -265,9 +265,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "ikt13crnhy"
 										return &v
@@ -306,12 +306,12 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											// AdditionalProperties: map[string]interface{}{},
+											// AdditionalProperties: map[string]any{},
 										}
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(1197)
 										return &v
@@ -331,9 +331,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "vsp1ewtr9m"
 										return &v
@@ -372,8 +372,8 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											AdditionalProperties: map[string]interface{}{
-												"errorMessage": map[string]interface{}{
+											AdditionalProperties: map[string]any{
+												"errorMessage": map[string]any{
 													"value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Error\"\n      }\n    ]\n  }\n]",
 												},
 											},
@@ -381,7 +381,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(1197)
 										return &v
@@ -401,9 +401,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "xb74p6rkd8"
 										return &v
@@ -442,7 +442,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											// AdditionalProperties: map[string]interface{}{},
+											// AdditionalProperties: map[string]any{},
 											SubFlowID: func() *davinci.SubFlowID {
 												return &davinci.SubFlowID{
 													Value: &davinci.SubFlowValue{
@@ -471,7 +471,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(867)
 										return &v
@@ -491,9 +491,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "kq5ybvwvro"
 										return &v
@@ -532,7 +532,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											// AdditionalProperties: map[string]interface{}{},
+											// AdditionalProperties: map[string]any{},
 											SubFlowID: func() *davinci.SubFlowID {
 												return &davinci.SubFlowID{
 													Value: &davinci.SubFlowValue{
@@ -561,7 +561,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(867)
 										return &v
@@ -581,9 +581,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "j74pmg6577"
 										return &v
@@ -594,7 +594,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(1017)
 										return &v
@@ -614,9 +614,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "pensvkew7y"
 										return &v
@@ -628,7 +628,7 @@ func Data_FullBasic() davinci.Flow {
 									Properties: nil,
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(1032)
 										return &v
@@ -648,9 +648,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "3zvjdgdljx"
 										return &v
@@ -689,13 +689,13 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 									Properties: func() *davinci.Properties {
 										return &davinci.Properties{
-											// AdditionalProperties: map[string]interface{}{},
+											// AdditionalProperties: map[string]any{},
 											SaveFlowVariables: func() *davinci.SaveFlowVariables {
 												return &davinci.SaveFlowVariables{
 													Value: func() []davinci.SaveFlowVariable {
 														return []davinci.SaveFlowVariable{
 															{
-																// AdditionalProperties: map[string]interface{}{},
+																// AdditionalProperties: map[string]any{},
 																Name: "fdgdfgfdg",
 																Value: func() *string {
 																	v := "[\n  {\n    \"children\": [\n      {\n        \"text\": \"test124\"\n      }\n    ]\n  }\n]"
@@ -712,7 +712,7 @@ func Data_FullBasic() davinci.Flow {
 																Type: "string",
 															},
 															{
-																// AdditionalProperties: map[string]interface{}{},
+																// AdditionalProperties: map[string]any{},
 																Name: "test123",
 																Value: func() *string {
 																	v := "[\n  {\n    \"children\": [\n      {\n        \"text\": \"test456\"\n      }\n    ]\n  }\n]"
@@ -736,7 +736,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(270)
 										return &v
@@ -756,9 +756,9 @@ func Data_FullBasic() davinci.Flow {
 								Classes:    "",
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.NodeData{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "bbemfztdyk"
 										return &v
@@ -769,7 +769,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(273.5)
 										return &v
@@ -791,12 +791,12 @@ func Data_FullBasic() davinci.Flow {
 						},
 						Edges: []davinci.Edge{
 							{
-								AdditionalProperties: map[string]interface{}{
+								AdditionalProperties: map[string]any{
 									"custom-attribute-1": "custom-attribute-1-value",
 									"custom-attribute-2": "custom-attribute-2-value",
 								},
 								Data: &davinci.Data{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"custom-attribute-1": "custom-attribute-1-value",
 										"custom-attribute-2": "custom-attribute-2-value",
 									},
@@ -814,7 +814,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"custom-attribute-1": "custom-attribute-1-value",
 										"custom-attribute-2": "custom-attribute-2-value",
 									},
@@ -861,9 +861,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "ljavni2nky"
 										return &v
@@ -878,7 +878,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -922,9 +922,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "0o2fqy3mf3"
 										return &v
@@ -939,7 +939,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -983,9 +983,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "493yd0jbi6"
 										return &v
@@ -1000,7 +1000,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1044,9 +1044,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "pn2kixnzms"
 										return &v
@@ -1061,7 +1061,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1105,9 +1105,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "0sb4quzlgx"
 										return &v
@@ -1122,7 +1122,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1166,9 +1166,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "v5p4i55lt9"
 										return &v
@@ -1183,7 +1183,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1227,9 +1227,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "k0trrhjqt6"
 										return &v
@@ -1244,7 +1244,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1288,9 +1288,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "2g0chago4l"
 										return &v
@@ -1305,7 +1305,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1349,9 +1349,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "gs1fx4x303"
 										return &v
@@ -1366,7 +1366,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1410,9 +1410,9 @@ func Data_FullBasic() davinci.Flow {
 								}(),
 							},
 							{
-								// AdditionalProperties: map[string]interface{}{},
+								// AdditionalProperties: map[string]any{},
 								Data: &davinci.Data{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									ID: func() *string {
 										v := "cum544luro"
 										return &v
@@ -1427,7 +1427,7 @@ func Data_FullBasic() davinci.Flow {
 									}(),
 								},
 								Position: &davinci.Position{
-									// AdditionalProperties: map[string]interface{}{},
+									// AdditionalProperties: map[string]any{},
 									X: func() *float64 {
 										v := float64(0)
 										return &v
@@ -1473,7 +1473,7 @@ func Data_FullBasic() davinci.Flow {
 						},
 					},
 					Data: &davinci.Data{
-						AdditionalProperties: map[string]interface{}{
+						AdditionalProperties: map[string]any{
 							"custom-attribute-1": "custom-attribute-1-value",
 							"custom-attribute-2": "custom-attribute-2-value",
 						},
@@ -1507,7 +1507,7 @@ func Data_FullBasic() davinci.Flow {
 						return &v
 					}(),
 					Pan: &davinci.Pan{
-						AdditionalProperties: map[string]interface{}{
+						AdditionalProperties: map[string]any{
 							"custom-attribute-1": "custom-attribute-1-value",
 							"custom-attribute-2": "custom-attribute-2-value",
 						},
@@ -1525,7 +1525,7 @@ func Data_FullBasic() davinci.Flow {
 						return &v
 					}(),
 					Renderer: &davinci.Renderer{
-						AdditionalProperties: map[string]interface{}{
+						AdditionalProperties: map[string]any{
 							"custom-attribute-1": "custom-attribute-1-value",
 							"custom-attribute-2": "custom-attribute-2-value",
 						},
@@ -1576,7 +1576,7 @@ func Data_FullBasic() davinci.Flow {
 			OutputSchemaCompiled: nil,
 			Variables: []davinci.FlowVariable{
 				{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-attribute-1-value",
 						"custom-attribute-2": "custom-attribute-2-value",
 					},
@@ -1590,7 +1590,7 @@ func Data_FullBasic() davinci.Flow {
 						return &v
 					}(),
 					Fields: &davinci.FlowVariableFields{
-						AdditionalProperties: map[string]interface{}{
+						AdditionalProperties: map[string]any{
 							"custom-attribute-1": "custom-attribute-1-value",
 							"custom-attribute-2": "custom-attribute-2-value",
 						},
@@ -1633,7 +1633,7 @@ func Data_FullBasic() davinci.Flow {
 					}(),
 				},
 				{
-					// AdditionalProperties: map[string]interface{}{},
+					// AdditionalProperties: map[string]any{},
 					Context: func() *string {
 						v := "flow"
 						return &v
@@ -1644,7 +1644,7 @@ func Data_FullBasic() davinci.Flow {
 						return &v
 					}(),
 					Fields: &davinci.FlowVariableFields{
-						// AdditionalProperties: map[string]interface{}{},
+						// AdditionalProperties: map[string]any{},
 						Type: func() *string {
 							v := "number"
 							return &v

--- a/davinci/unmarshal_test.go
+++ b/davinci/unmarshal_test.go
@@ -93,8 +93,8 @@ func TestUnmarshal_AdditionalProperties(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !cmp.Equal(newObj.AdditionalProperties, map[string]interface{}{}, cmpopts.EquateEmpty()) {
-			t.Fatalf("Additional Properties Equality failure (-want, +got):\n%s", cmp.Diff(map[string]interface{}{}, newObj.AdditionalProperties))
+		if !cmp.Equal(newObj.AdditionalProperties, map[string]any{}, cmpopts.EquateEmpty()) {
+			t.Fatalf("Additional Properties Equality failure (-want, +got):\n%s", cmp.Diff(map[string]any{}, newObj.AdditionalProperties))
 		}
 	})
 
@@ -112,7 +112,7 @@ func TestUnmarshal_AdditionalProperties(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		additionalProperties := map[string]interface{}{
+		additionalProperties := map[string]any{
 			"custom-attribute-1": "custom-value-1",
 			"custom-attribute-2": "custom-value-2",
 		}
@@ -145,7 +145,7 @@ func TestUnmarshal_AdditionalProperties(t *testing.T) {
 		}
 
 		expectedObj := davinci.Position{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -176,8 +176,8 @@ func TestUnmarshal_Nested_AdditionalProperties(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !cmp.Equal(newObj.Fields.AdditionalProperties, map[string]interface{}{}, cmpopts.EquateEmpty()) {
-			t.Fatalf("Additional Properties Equality failure (-want, +got):\n%s", cmp.Diff(map[string]interface{}{}, newObj.AdditionalProperties))
+		if !cmp.Equal(newObj.Fields.AdditionalProperties, map[string]any{}, cmpopts.EquateEmpty()) {
+			t.Fatalf("Additional Properties Equality failure (-want, +got):\n%s", cmp.Diff(map[string]any{}, newObj.AdditionalProperties))
 		}
 	})
 
@@ -197,7 +197,7 @@ func TestUnmarshal_Nested_AdditionalProperties(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		additionalProperties := map[string]interface{}{
+		additionalProperties := map[string]any{
 			"custom-attribute-1": "custom-value-1",
 			"custom-attribute-2": "custom-value-2",
 		}
@@ -232,12 +232,12 @@ func TestUnmarshal_Nested_AdditionalProperties(t *testing.T) {
 		}
 
 		expectedObj := davinci.FlowVariable{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
 			Fields: &davinci.FlowVariableFields{
-				AdditionalProperties: map[string]interface{}{
+				AdditionalProperties: map[string]any{
 					"custom-attribute-1": "custom-value-1",
 					"custom-attribute-2": "custom-value-2",
 				},
@@ -282,7 +282,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -292,7 +292,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-value-1",
 						"custom-attribute-2": "custom-value-2",
 					},
@@ -350,7 +350,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -360,7 +360,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-value-1",
 						"custom-attribute-2": "custom-value-2",
 					},
@@ -418,7 +418,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -428,7 +428,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			//Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-value-1",
 						"custom-attribute-2": "custom-value-2",
 					},
@@ -486,7 +486,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			//AdditionalProperties: map[string]interface{}{
+			//AdditionalProperties: map[string]any{
 			//	"custom-attribute-1": "custom-value-1",
 			//	"custom-attribute-2": "custom-value-2",
 			//},
@@ -496,7 +496,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					// AdditionalProperties: map[string]interface{}{
+					// AdditionalProperties: map[string]any{
 					// 	"custom-attribute-1": "custom-value-1",
 					// 	"custom-attribute-2": "custom-value-2",
 					// },
@@ -554,7 +554,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -564,7 +564,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-value-1",
 						"custom-attribute-2": "custom-value-2",
 					},
@@ -622,7 +622,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 		}
 
 		expectedObj := test.TestModel{
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"custom-attribute-1": "custom-value-1",
 				"custom-attribute-2": "custom-value-2",
 			},
@@ -632,7 +632,7 @@ func TestUnmarshal_Filter(t *testing.T) {
 			Test4: func() *string { s := "test4Value"; return &s }(),
 			Test5: func() *test.TestModel2 {
 				s := test.TestModel2{
-					AdditionalProperties: map[string]interface{}{
+					AdditionalProperties: map[string]any{
 						"custom-attribute-1": "custom-value-1",
 						"custom-attribute-2": "custom-value-2",
 					},

--- a/davinci/variables_test.go
+++ b/davinci/variables_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/samir-gandhi/davinci-client-go/tools"
 )
 
-var testDataVars = map[string]interface{}{
+var testDataVars = map[string]any{
 	"params": map[string]davinci.Params{
 		"a": {
 			Page:  "0",


### PR DESCRIPTION
The product team need to add a default to the `settings.logLevel` field, which the SDK considers "configuration" for flow diff purposes.  In reality, log level is an environment-specific setting, so this PR expands the `settings` data model with `logLevel` set as an environment specific field.
Also modernises some code based on IDE recommendations