### PR TITLE
Fix zero length marshal errors

### DIFF
--- a/davinci/models_flow_settings.go
+++ b/davinci/models_flow_settings.go
@@ -7,24 +7,24 @@ import (
 
 type _FlowSettings FlowSettings
 type FlowSettings struct {
-	AdditionalProperties map[string]any           `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
-	Csp                  *FlowSettingsStringValue `json:"csp,omitempty" davinci:"csp,config,omitempty"`
-	Css                  *FlowSettingsStringValue `json:"css,omitempty" davinci:"css,config,omitempty"`
-	// CssLinks                        *[]string                `json:"cssLinks,omitempty" davinci:"cssLinks,config,omitempty"`
-	DebugMode                     *bool                    `json:"debugMode,omitempty" davinci:"debugMode,environmentmetadata,omitempty"`
-	FlowHttpTimeoutInSeconds      *int32                   `json:"flowHttpTimeoutInSeconds,omitempty" davinci:"flowHttpTimeoutInSeconds,config,omitempty"`
-	FlowTimeoutInSeconds          *int32                   `json:"flowTimeoutInSeconds,omitempty" davinci:"flowTimeoutInSeconds,config,omitempty"`
-	IntermediateLoadingScreenCSS  *FlowSettingsStringValue `json:"intermediateLoadingScreenCSS,omitempty" davinci:"intermediateLoadingScreenCSS,config,omitempty"`
-	IntermediateLoadingScreenHTML *FlowSettingsStringValue `json:"intermediateLoadingScreenHTML,omitempty" davinci:"intermediateLoadingScreenHTML,config,omitempty"`
-	// JsLinks                         *[]string                `json:"jsLinks,omitempty" davinci:"jsLinks,config,omitempty"`
-	LogLevel                        *int32       `json:"logLevel,omitempty" davinci:"logLevel,environmentmetadata,omitempty"`
-	PingOneFlow                     *bool        `json:"pingOneFlow,omitempty" davinci:"pingOneFlow,config,omitempty"`
-	RequireAuthenticationToInitiate *bool        `json:"requireAuthenticationToInitiate,omitempty" davinci:"requireAuthenticationToInitiate,config,omitempty"`
-	ScrubSensitiveInfo              *bool        `json:"scrubSensitiveInfo,omitempty" davinci:"scrubSensitiveInfo,config,omitempty"`
-	SensitiveInfoFields             *interface{} `json:"sensitiveInfoFields,omitempty" davinci:"sensitiveInfoFields,config,omitempty"`
-	UseBetaAlgorithm                *bool        `json:"useBetaAlgorithm,omitempty" davinci:"useBetaAlgorithm,config,omitempty"`
-	UseCustomCSS                    *bool        `json:"useCustomCSS,omitempty" davinci:"useCustomCSS,config,omitempty"`
-	UseCustomScript                 *bool        `json:"useCustomScript,omitempty" davinci:"useCustomScript,config,omitempty"`
+	AdditionalProperties            map[string]any           `json:"-" davinci:"-,unmappedproperties"` // used to capture all other properties that are not explicitly defined in the model
+	Csp                             *FlowSettingsStringValue `json:"csp,omitempty" davinci:"csp,config,omitempty"`
+	Css                             *FlowSettingsStringValue `json:"css,omitempty" davinci:"css,config,omitempty"`
+	CssLinks                        *[]string                `json:"cssLinks" davinci:"cssLinks,config"`
+	DebugMode                       *bool                    `json:"debugMode,omitempty" davinci:"debugMode,environmentmetadata,omitempty"`
+	FlowHttpTimeoutInSeconds        *int32                   `json:"flowHttpTimeoutInSeconds,omitempty" davinci:"flowHttpTimeoutInSeconds,config,omitempty"`
+	FlowTimeoutInSeconds            *int32                   `json:"flowTimeoutInSeconds,omitempty" davinci:"flowTimeoutInSeconds,config,omitempty"`
+	IntermediateLoadingScreenCSS    *FlowSettingsStringValue `json:"intermediateLoadingScreenCSS,omitempty" davinci:"intermediateLoadingScreenCSS,config,omitempty"`
+	IntermediateLoadingScreenHTML   *FlowSettingsStringValue `json:"intermediateLoadingScreenHTML,omitempty" davinci:"intermediateLoadingScreenHTML,config,omitempty"`
+	JsLinks                         *[]string                `json:"jsLinks" davinci:"jsLinks,config"`
+	LogLevel                        *int32                   `json:"logLevel,omitempty" davinci:"logLevel,environmentmetadata,omitempty"`
+	PingOneFlow                     *bool                    `json:"pingOneFlow,omitempty" davinci:"pingOneFlow,config,omitempty"`
+	RequireAuthenticationToInitiate *bool                    `json:"requireAuthenticationToInitiate,omitempty" davinci:"requireAuthenticationToInitiate,config,omitempty"`
+	ScrubSensitiveInfo              *bool                    `json:"scrubSensitiveInfo,omitempty" davinci:"scrubSensitiveInfo,config,omitempty"`
+	SensitiveInfoFields             *interface{}             `json:"sensitiveInfoFields,omitempty" davinci:"sensitiveInfoFields,config,omitempty"`
+	UseBetaAlgorithm                *bool                    `json:"useBetaAlgorithm,omitempty" davinci:"useBetaAlgorithm,config,omitempty"`
+	UseCustomCSS                    *bool                    `json:"useCustomCSS,omitempty" davinci:"useCustomCSS,config,omitempty"`
+	UseCustomScript                 *bool                    `json:"useCustomScript,omitempty" davinci:"useCustomScript,config,omitempty"`
 }
 
 func (o FlowSettings) MarshalJSON() ([]byte, error) {
@@ -47,9 +47,13 @@ func (o FlowSettings) ToMap() (map[string]any, error) {
 		result["css"] = o.Css
 	}
 
-	// if o.CssLinks != nil {
-	// 	result["cssLinks"] = o.CssLinks
-	// }
+	if o.CssLinks != nil {
+		if len(*o.CssLinks) == 0 {
+			result["cssLinks"] = []string{}
+		} else {
+			result["cssLinks"] = o.CssLinks
+		}
+	}
 
 	if o.DebugMode != nil {
 		result["debugMode"] = o.DebugMode
@@ -71,9 +75,13 @@ func (o FlowSettings) ToMap() (map[string]any, error) {
 		result["intermediateLoadingScreenHTML"] = o.IntermediateLoadingScreenHTML
 	}
 
-	// if o.JsLinks != nil {
-	// 	result["jsLinks"] = o.JsLinks
-	// }
+	if o.JsLinks != nil {
+		if len(*o.JsLinks) == 0 {
+			result["jsLinks"] = []string{}
+		} else {
+			result["jsLinks"] = o.JsLinks
+		}
+	}
 
 	if o.LogLevel != nil {
 		result["logLevel"] = o.LogLevel
@@ -124,13 +132,13 @@ func (o *FlowSettings) UnmarshalJSON(bytes []byte) (err error) {
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "csp")
 		delete(additionalProperties, "css")
-		// delete(additionalProperties, "cssLinks")
+		delete(additionalProperties, "cssLinks")
 		delete(additionalProperties, "debugMode")
 		delete(additionalProperties, "flowHttpTimeoutInSeconds")
 		delete(additionalProperties, "flowTimeoutInSeconds")
 		delete(additionalProperties, "intermediateLoadingScreenCSS")
 		delete(additionalProperties, "intermediateLoadingScreenHTML")
-		// delete(additionalProperties, "jsLinks")
+		delete(additionalProperties, "jsLinks")
 		delete(additionalProperties, "logLevel")
 		delete(additionalProperties, "pingOneFlow")
 		delete(additionalProperties, "requireAuthenticationToInitiate")


### PR DESCRIPTION
Fix zero length marshal errors (the flow JSON has `cssLinks=[]` or `jsLinks=[]` and the marshal routine translates these to null, leading to a material difference between before and after).